### PR TITLE
docs: update chagelog.mdx checkout to versión 2.21.0

### DIFF
--- a/src/pages/checkout/api/changelog.mdx
+++ b/src/pages/checkout/api/changelog.mdx
@@ -1,9 +1,21 @@
+export const sectionMode = 'none'
 export const description =
   'Conoce el historial de cambios de Checkout API y aprovecha las nuevas funcionalidades.'
 
 # Historial de cambios - Changelog
 
 Este archivo contiene las mejoras y actualizaciones que se hagan en Checkout API.
+
+## Undeployed {{ id: 'undeployed' }}
+
+...
+
+## `2.21.8` 2024-07-25
+
+### Cambió:
+- Agrega validación para detectar tarjetas bancarias en las propiedades `buyer` y `payer` en los campos `name`, `surname`, `document`, y `mobile` en el endpoint `/api/session`.
+    - `buyer`: Ahora, cuando los campos  `name`, `surname`, `document`, y `mobile` contienen el valor de una tarjeta bancaria, se elimina de la propiedad de la solicitud.
+    - `payer`: Ahora, cuando los campos  `name`, `surname`, `document`, y `mobile` contienen el valor de una tarjeta bancaria, responde con un error `status.status` `FAILED` y `status.reason` `payer_data_not_valid`.
 
 ## `2.20.0` 2024-05-02
 

--- a/src/pages/en/checkout/api/changelog.mdx
+++ b/src/pages/en/checkout/api/changelog.mdx
@@ -10,6 +10,13 @@ This file contains the improvements and updates made to the Checkout API.
 
 ...
 
+## `2.21.8` 2024-07-25
+
+### Changed:
+-  Add validation to detect bank cards in the `buyer` and `payer` properties in the `name`, `surname`, `document`, and `mobile` fields in the `/api/session` endpoint.
+    - `buyer`: Now, when the fields `name`, `surname`, `document`, and `mobile` contain the value of a bank card, it is removed from the property of the request.
+    - `payer`: Now, when the fields `name`, `surname`, `document`, and `mobile` contain the value of a bank card, it responds with an error `status.status` `FAILED` and `status.reason` as `payer_data_not_valid`.
+
 ## `2.20.0` 2024-05-02
 
 ### Added:


### PR DESCRIPTION
Adds descriptions for the new validations in secondary payer and buyer fields in the endpoint to create session.