### PR TITLE
feat: adds library for python integration

### DIFF
--- a/src/components/Libraries.jsx
+++ b/src/components/Libraries.jsx
@@ -6,6 +6,7 @@ import logoPrestashop from '@/images/logos/prestashop.svg'
 import logoCSharp from '@/images/logos/csharp.svg'
 import logoJava from '@/images/logos/java.svg'
 import logoPhp from '@/images/logos/php.svg'
+import logoPython from '@/images/logos/python.svg'
 import logoShopify from '@/images/logos/shopify.svg'
 import logoVtex from '@/images/logos/vtex.svg'
 import logoJumpseller from '@/images/logos/jumpseller.svg'
@@ -103,6 +104,16 @@ const libraries = [
       en: 'High level and object oriented programming language',
     },
     logo: logoJava,
+    action: { es: 'Ver más', en: 'See more' },
+  },
+  {
+    href: 'https://github.com/andrextor/python-checkout',
+    name: 'Python',
+    description: {
+      es: 'Lenguaje de programación versátil y de alto nivel, ampliamente utilizado en el desarrollo de aplicaciones modernas.',
+      en: 'Versatile and high-level programming language, widely used in modern application development.',
+    },
+    logo: logoPython,
     action: { es: 'Ver más', en: 'See more' },
   },
 ]


### PR DESCRIPTION
Propuesta para añadir una librería que facilite la integración de la pasarela de pagos Web Checkout utilizando el lenguaje de programación Python. La librería cuenta con documentación clara y detallada en el repositorio, proporcionando ejemplos y recursos adicionales para una implementación rápida y eficiente.

[python-checkout](https://github.com/andrextor/python-checkout)

![image](https://github.com/user-attachments/assets/27366a9c-d662-4f83-95a3-8d5d5b74b257)
