### PR TITLE
feat: remove pilot version note

### DIFF
--- a/src/pages/en/payment-links/index.mdx
+++ b/src/pages/en/payment-links/index.mdx
@@ -21,8 +21,4 @@ See how to use each feature in the API - Payment Links section:
 
 - [Create a link](/en/payment-links/api/reference/payment-links#create-a-link)
 - [Get a link](/en/payment-links/api/reference/payment-links#get-a-link)
-- [Disable a link](/en/payment-links/api/reference/payment-links#disable-a-link) 
-
-> #### Pilot Version
->
-> The API is currently in the pilot version. During this phase, tests will be conducted to certify its effectiveness and stability. Participating developers are encouraged to use the pilot version to experiment with the API and provide valuable feedback for its continuous improvement.
+- [Disable a link](/en/payment-links/api/reference/payment-links#disable-a-link)

--- a/src/pages/payment-links/index.mdx
+++ b/src/pages/payment-links/index.mdx
@@ -21,7 +21,3 @@ Consulta como usar cada funcionalidad en el apartado de API - Link de pagos
 - [Creación de un link](/payment-links/api/reference/payment-links#create-a-link)
 - [Consulta de un link](/payment-links/api/reference/payment-links#get-a-link)
 - [Inactivación de un link](/payment-links/api/reference/payment-links#disable-a-link)
-
-> #### Version Piloto
->
-> Actualmente la API se encuentra en la versión piloto. Durante esta fase, se realizarán pruebas para certificar su efectividad y estabilidad. Se recomienda a los desarrolladores participantes utilizar la versión piloto para experimentar con la API y proporcionar retroalimentación valiosa para su mejora continua.


### PR DESCRIPTION
La nota que indicaba que la API de links de pagos de Micrositios se encontraba en la version piloto ya no es necesario que se muestre