### PR TITLE
feat: update dispersion docs to fix taxes example

### DIFF
--- a/src/pages/checkout/create-session.mdx
+++ b/src/pages/checkout/create-session.mdx
@@ -151,7 +151,7 @@ Para hacer uso de esta funcionalidad es importante conocer el identificador del 
 - La suma total de las dispersiones deben ser igual al total del pago.
 - Todas las monedas de las dispersiones deben ser igual a la moneda del pago
 
-Para el envió de impuestos, es importante que se encuentre en la estructura de cada una de las dispersiones
+Para el envió de impuestos, es importante que se agreguen en la estructura [amount](/payments/microsite-customized/data-structures#amount) de cada una de las dispersiones
 
 ```json {{ 'title': 'CreateSessionRequest - Dispersion Payment Taxes' }}
 {
@@ -162,24 +162,23 @@ Para el envió de impuestos, es importante que se encuentre en la estructura de 
             {
                 "amount": {
                     "total": 700,
-                    "currency": "USD"
+                    "currency": "USD",
+                    "taxes": [
+                        {
+                            "kind": "airportTax",
+                            "amount": 16.13
+                        }
+                    ],
+                    "details": [
+                        {
+                            "kind": "tip",
+                            "amount": 11
+                        }
+                    ]
                 },
                 "agreement": 30,
                 "agreementType": "AIRLINE",
-                "taxes": [
-                    {
-                        "kind": "airportTax",
-                        "amount": 16.13
-                    }
-                ],
-                "details": [
-                    {
-                        "kind": "tip",
-                        "amount": 11
-                    }
-                ]
             },
-            
         ],
     }
     ...

--- a/src/pages/en/checkout/create-session.mdx
+++ b/src/pages/en/checkout/create-session.mdx
@@ -151,7 +151,7 @@ To make use of this functionality it is important to know the identifier of the 
 - The total sum of the scatters must be equal to the total payout.
 - All scatter coins must be equal to the payout currency
 
-For the sending of taxes, it is important that it is in the structure of each of the dispersions
+For the sending of taxes, it is important that it is in the [amount](/payments/microsite-customized/data-structures#amount) structure of each of the dispersions
 
 ```json {{ 'title': 'CreateSessionRequest - Dispersion Payment Taxes' }}
 {
@@ -162,24 +162,23 @@ For the sending of taxes, it is important that it is in the structure of each of
             {
                 "amount": {
                     "total": 700,
-                    "currency": "USD"
+                    "currency": "USD",
+                    "taxes": [
+                        {
+                            "kind": "airportTax",
+                            "amount": 16.13
+                        }
+                    ],
+                    "details": [
+                        {
+                            "kind": "tip",
+                            "amount": 11
+                        }
+                    ]
                 },
                 "agreement": 30,
                 "agreementType": "AIRLINE",
-                "taxes": [
-                    {
-                        "kind": "airportTax",
-                        "amount": 16.13
-                    }
-                ],
-                "details": [
-                    {
-                        "kind": "tip",
-                        "amount": 11
-                    }
-                ]
             },
-            
         ],
     }
     ...


### PR DESCRIPTION
Se corrige el ejemplo del request que incluye los impuestos en /checkout/create-session#dispersion-payment. El elemento `taxes` se ubica dentro de `amount`.