### PR TITLE
fix: Add property additional.initiatorIndicator in example «V2x Pago»…

### DIFF
--- a/src/pages/en/gateway/api/reference/3ds.mdx
+++ b/src/pages/en/gateway/api/reference/3ds.mdx
@@ -66,7 +66,10 @@ Performs the initial validation process of [3DS Server](/three-d-s-server/api/in
                     }
                 },
                 "returnUrl": "https://www.your-site.com/return?reference=1234567890",
-                "version": "v2x"
+                "version": "v2x",
+                "additional": {
+                    "initiatorIndicator": "AGENT"
+                }
             }
             '
             ```

--- a/src/pages/gateway/api/reference/3ds.mdx
+++ b/src/pages/gateway/api/reference/3ds.mdx
@@ -66,7 +66,10 @@ Realiza el proceso inicial de validación de [3DS Server](/three-d-s-server/api/
                     }
                 },
                 "returnUrl": "https://www.your-site.com/return?reference=1234567890",
-                "version": "v2x"
+                "version": "v2x",
+                "additional": {
+                    "initiatorIndicator": "AGENT"
+                }
             }
             '
             ```


### PR DESCRIPTION
Se carga  propiedad `additiona.initiatorIndicator` en  el ejemplo Pago V2x del endpoint «gateway/lookup» 