### PR TITLE
chore: rename metadata key InitiatorIndicator to initiatorIndicator

### DIFF
--- a/src/pages/checkout/metadata.mdx
+++ b/src/pages/checkout/metadata.mdx
@@ -15,7 +15,7 @@ Actualmente, la estructura de clave-valor puede incluirse en las solicitudes de 
 
 | Clave                  | Valores permitidos | Descripción |
 |------------------------|--------------------|---------------------------------------------|
-| `InitiatorIndicator`   | `AGENT`            | Indica que el procesamiento de la sesión será realizado por un agente en nombre del tarjetahabiente. |
+| `initiatorIndicator`   | `AGENT`            | Indica que el procesamiento de la sesión será realizado por un agente en nombre del tarjetahabiente. |
 | `EBTDeliveryIndicator` | `DIRECT_DELIVERY`, `CUSTOMER_PICKUP`, `COMMERCIAL_SHIPPING`, `OTHER`, `NOT_AVAILABLE` | Indica el método de entrega relacionado con el beneficio EBT. |
 | `openingDate`          | `string` con formato de fecha (YYYY-MM-DD) | Fecha de creación de cuenta. Requerida para PSE en comercios con categoría “Servicios Financieros”. |
 | `beneficiaryId`        | `string`           | ID del beneficiario asociado a la cuenta receptora en una transacción PSE. Requerido para comercios con categoría “Servicios Financieros”. |
@@ -34,7 +34,7 @@ La propiedad `metadata` se puede incluir dentro de la estructura principal de la
    "auth": {...},
    "payment": {...},
    "metadata" : {
-      "InitiatorIndicator": "AGENT",
+      "initiatorIndicator": "AGENT",
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",
@@ -49,7 +49,7 @@ La propiedad `metadata` se puede incluir dentro de la estructura principal de la
    "auth": {...},
    "payment": {...},
    "metadata" : {
-      "InitiatorIndicator": "AGENT",
+      "initiatorIndicator": "AGENT",
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",

--- a/src/pages/en/checkout/metadata.mdx
+++ b/src/pages/en/checkout/metadata.mdx
@@ -15,7 +15,7 @@ Currently, the key-value structure can be included in requests to the following 
 
 | Key                    | Allowed Values | Description |
 |------------------------|--------------------|---------------------------------------------|
-| `InitiatorIndicator`   | `AGENT`            | Indicates that the session processing will be carried out by an agent on behalf of the cardholder. |
+| `initiatorIndicator`   | `AGENT`            | Indicates that the session processing will be carried out by an agent on behalf of the cardholder. |
 | `EBTDeliveryIndicator` | `DIRECT_DELIVERY`, `CUSTOMER_PICKUP`, `COMMERCIAL_SHIPPING`, `OTHER`, `NOT_AVAILABLE` | Indicates the delivery method related to the EBT benefit. |
 | `openingDate`          | `string` in date format (YYYY-MM-DD) | Account creation date. Required for PSE in merchants with “Financial Services” category. |
 | `beneficiaryId`        | `string`           | Beneficiary ID linked to the receiving account in a PSE transaction. Required for merchants in the “Financial Services” category. |
@@ -34,7 +34,7 @@ The `metadata` property can be included in the main structure of the request in 
    "auth": {...},
    "payment": {...},
    "metadata" : {
-      "InitiatorIndicator": "AGENT",
+      "initiatorIndicator": "AGENT",
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",
@@ -49,7 +49,7 @@ The `metadata` property can be included in the main structure of the request in 
    "auth": {...},
    "payment": {...},
    "metadata" : {
-      "InitiatorIndicator": "AGENT",
+      "initiatorIndicator": "AGENT",
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",


### PR DESCRIPTION
Se actualiza el nombre de la clave `InitiatorIndicator` a `initiatorIndicator` dentro de la propiedad metadata, https://docs.placetopay.dev/checkout/metadata.