### PR TITLE
feat: add browser support documentation to WebCheckout

### DIFF
--- a/src/constants/navigations.js
+++ b/src/constants/navigations.js
@@ -445,6 +445,7 @@ export const TAB_NAVIGATION = {
               { title: 'Cómo Funciona', href: '/checkout/how-checkout-works' },
               { title: 'Plugins', href: '/checkout/plugins' },
               { title: 'Lightbox', href: '/checkout/lightbox' },
+              { title: 'Navegadores soportados', href: '/checkout/support-browser' },
             ],
           },
           {
@@ -536,6 +537,7 @@ export const TAB_NAVIGATION = {
               { title: 'How it works', href: '/checkout/how-checkout-works' },
               { title: 'Plugins', href: '/checkout/plugins' },
               { title: 'Lightbox', href: '/checkout/lightbox' },
+              { title: 'Supported browser', href: '/checkout/support-browser' },
             ],
           },
           {

--- a/src/pages/checkout/support-browser.mdx
+++ b/src/pages/checkout/support-browser.mdx
@@ -1,0 +1,43 @@
+export const description = 'Navegadores compatibles con el uso de la aplicación Web Checkout.'
+
+# Navegadores Compatibles
+
+WebCheckout está diseñada para ofrecer una experiencia segura y estable en las versiones modernas de los navegadores más utilizados.  
+No se garantiza el soporte para navegadores desactualizados que ya no reciben actualizaciones de seguridad o tienen un uso muy limitado.
+
+Recomendamos mantener los sistemas y navegadores actualizados para asegurar la mejor experiencia posible.
+
+## Navegadores de escritorio soportados
+
+- Google Chrome 131+ — **17.9%**  
+- Mozilla Firefox 133+ — **1.52%**  
+- Microsoft Edge 131+ — **4.5%**  
+- Safari 18.1+ — **1.38%**  
+- Opera 114+ — **0.31%**  
+- Samsung Internet 27+ (desktop) — **1.9%**
+
+## Navegadores móviles soportados
+
+- Chrome para Android 132 — **46.1%**  
+- Safari en iOS 18.1+ — **9.1%**  
+- Samsung Internet 27+ — **1.9%**  
+- Firefox para Android 132 — **0.33%**  
+- UC Browser 15.5 — **0.83%**  
+
+<Note>
+Estos valores corresponden a la regla Browserslist utilizada en el proyecto: [> 0.5%, last 2 versions, not dead, not op_mini all, not IE 11](https://browserslist.dev/?q=PiAwLjUlLCBsYXN0IDIgdmVyc2lvbnMsIG5vdCBkZWFkLCBub3Qgb3BfbWluaSBhbGwsIG5vdCBJRSAxMQ%3D%3D).
+</Note>
+
+## Navegadores no compatibles o con soporte limitado
+
+- **Internet Explorer 11**  
+- **Opera Mini**  
+- Navegadores que no cumplan los requisitos mínimos
+
+## Requisitos mínimos del navegador {{ id: "requisitos-navegador" }}
+
+Para que la aplicación funcione correctamente, el navegador debe cumplir con lo siguiente:
+
+- Soporte para **TLS 1.2** o superior  
+- Soporte para **Promises** en JavaScript  
+- Motor actualizado con soporte para estándares modernos de HTML5 y CSS3

--- a/src/pages/en/checkout/support-browser.mdx
+++ b/src/pages/en/checkout/support-browser.mdx
@@ -1,0 +1,43 @@
+export const description = 'Supported browsers for using the Web Checkout application.'
+
+# Supported Browsers
+
+WebCheckout is designed to provide a secure and stable experience on modern versions of the most widely used web browsers.  
+Support is not guaranteed for outdated browsers that no longer receive security updates or represent a very small share of global usage.
+
+We recommend keeping systems and browsers up to date to ensure the best possible experience.
+
+## Supported desktop browsers
+
+- Google Chrome 131+ — **17.9%**  
+- Mozilla Firefox 133+ — **1.52%**  
+- Microsoft Edge 131+ — **4.5%**  
+- Safari 18.1+ — **1.38%**  
+- Opera 114+ — **0.31%**  
+- Samsung Internet 27+ (desktop) — **1.9%**
+
+## Supported mobile browsers
+
+- Chrome for Android 132 — **46.1%**  
+- Safari on iOS 18.1+ — **9.1%**  
+- Samsung Internet 27+ — **1.9%**  
+- Firefox for Android 132 — **0.33%**  
+- UC Browser 15.5 — **0.83%**  
+
+<Note>
+These values correspond to the Browserslist rule used in the project: [> 0.5%, last 2 versions, not dead, not op_mini all, not IE 11](https://browserslist.dev/?q=PiAwLjUlLCBsYXN0IDIgdmVyc2lvbnMsIG5vdCBkZWFkLCBub3Qgb3BfbWluaSBhbGwsIG5vdCBJRSAxMQ%3D%3D).
+</Note>
+
+## Unsupported or partially supported browsers
+
+- **Internet Explorer 11**  
+- **Opera Mini**  
+- Browsers that do not meet the minimum requirements
+
+## Minimum browser requirements {{ id: "requisitos-navegador" }}
+
+To ensure proper functionality, the browser must support:
+
+- **TLS 1.2** or higher  
+- **Promises** in JavaScript  
+- An up-to-date engine with support for modern HTML5 and CSS3 standards 


### PR DESCRIPTION
Agrega una nueva sección a la documentación de WebCheckout con los navegadores y móviles soportados, requisitos mínimos y preguntas frecuentes.
![image](https://github.com/user-attachments/assets/f919a259-dad4-4969-8240-271742cf52a9)
