### PR TITLE
chore: remove required tag from payment.description field in API

### DIFF
--- a/src/assets/apis/checkout/en.yaml
+++ b/src/assets/apis/checkout/en.yaml
@@ -1554,7 +1554,6 @@ components:
         Requested payment information.
       required:
         - reference
-        - description
         - amount
       properties:
         reference:

--- a/src/assets/apis/checkout/es.yaml
+++ b/src/assets/apis/checkout/es.yaml
@@ -1539,7 +1539,6 @@ components:
         Información del pago solicitado.
       required:
         - reference
-        - description
         - amount
       properties:
         reference:


### PR DESCRIPTION
- Se elimina etiqueta "REQUIRED" para en campo `payment.description` en la api de Checkout, ya que este campo no es obligatorio para la creación de sesiones
