### PR TITLE
feat: add numeric type validation for the `payment.dispersion.*.agreement` property in the `CreateSessionRequest` Checkout endpoint.

### DIFF
--- a/src/assets/apis/checkout/en.yaml
+++ b/src/assets/apis/checkout/en.yaml
@@ -3050,7 +3050,6 @@ components:
             I ride to "scatter" in this destination.
         agreement:
           type:
-            - string
             - number
           description: |
             Id of the destination of this amount. It can be the id of a site.

--- a/src/assets/apis/checkout/en.yaml
+++ b/src/assets/apis/checkout/en.yaml
@@ -3049,6 +3049,7 @@ components:
           description: |
             I ride to "scatter" in this destination.
         agreement:
+          nullable: true
           type:
             - number
           description: |

--- a/src/assets/apis/checkout/es.yaml
+++ b/src/assets/apis/checkout/es.yaml
@@ -3034,11 +3034,9 @@ components:
             Monto a "dispersar" en este destino.
         agreement:
           type:
-            - string
             - number
           description: |
             Id del destino de este monto. Puede ser el id de un sitio.
-            
             EJ: `122`
         agreementType:
           type: string

--- a/src/assets/apis/checkout/es.yaml
+++ b/src/assets/apis/checkout/es.yaml
@@ -3033,6 +3033,7 @@ components:
           description: |
             Monto a "dispersar" en este destino.
         agreement:
+          nullable: true
           type:
             - number
           description: |

--- a/src/pages/checkout/api/changelog.mdx
+++ b/src/pages/checkout/api/changelog.mdx
@@ -6,6 +6,12 @@ export const description =
 
 Este archivo contiene las mejoras y actualizaciones que se hagan en Checkout API.
 
+## `2.28.4` 2024-09-01
+
+### Nuevo:
+
+- Validación de tipo `numeric` para las propiedades `payment.dispersion.*.agreement` en el endpoint `CreateSessionRequest`.
+
 ## `2.28.0` 2025-07-15
 
 ### Nuevo:

--- a/src/pages/en/checkout/api/changelog.mdx
+++ b/src/pages/en/checkout/api/changelog.mdx
@@ -6,6 +6,11 @@ export const description =
 
 This file contains the improvements and updates made to the Checkout API.
 
+## `2.28.4` 2024-09-01
+
+### Added:
+-  Numeric type validation for the `payment.dispersion.*.agreement` property in the `CreateSessionRequest` endpoint..
+
 ## `2.28.0` 2025-07-15
 
 ### Added:


### PR DESCRIPTION
- [x] Se modifica la validación para la propiedad `payment.dispersion.*.agreement` en pagos con dispersión. Ahora el valor enviado debe ser de tipo numérico:

ejemplo:
```json
{
"dispersion": [
            {
                "agreement": 1,
                "agreementType": "MERCHANT",
                "amount": {
                    "currency": "USD",
                    "total": 50
                }
            },
            {
                "agreement": "2",
                "agreementType": "MERCHANT",
                "amount": {
                    "currency": "USD",
                    "total": 25
                }
            }
        ]
}

```