### PR TITLE
feat: add `isGeneric` field to Payment Link Api

### DIFF
--- a/src/assets/apis/payment-links/en.yaml
+++ b/src/assets/apis/payment-links/en.yaml
@@ -245,6 +245,10 @@ paths:
                       type: string
                       description: |
                         Buyer's name.
+                isGeneric:
+                  type: boolean
+                  description: Allows the user to pay multiple times using the same link as long as the total limit of approved payments (`paymentsAllowed`) is not exceeded.
+                  default: false
       responses:
         "201":
           description: "Payment link created successfully"
@@ -729,6 +733,12 @@ paths:
                                 Payer's identity document type.
 
                                 EX: `CC`
+                  isGeneric:
+                    type: boolean
+                    description: |
+                      Indicates whether the user can pay multiple times using the same link.
+                      
+                      EJ: `false`
         "401":
           description: "Unauthorized (An attempt was made to query a link that does not belong to your site)"
           content:

--- a/src/assets/apis/payment-links/es.yaml
+++ b/src/assets/apis/payment-links/es.yaml
@@ -245,6 +245,10 @@ paths:
                       type: string
                       description: |
                         Nombre del comprador.
+                isGeneric:
+                  type: boolean
+                  description: Permite al usuario pagar múltiples veces usando el mismo link siempre y cuando no se supere el límite total de pagos aprobados (`paymentsAllowed`).
+                  default: false
       responses:
         "201":
           description: "Link de pago creado correctamente"
@@ -729,6 +733,13 @@ paths:
                                 Tipo de documento de identidad del pagador.
 
                                 EJ: `CC`
+
+                  isGeneric:
+                    type: boolean
+                    description: |
+                      Indica si el usuario puede pagar múltiples veces usando el mismo link.
+
+                      EJ: `false`
         "401":
           description: "No autorizado (Se intento consultar un link que no pertenece a tu sitio)"
           content:

--- a/src/pages/en/payment-links/api/reference/payment-links.mdx
+++ b/src/pages/en/payment-links/api/reference/payment-links.mdx
@@ -248,7 +248,8 @@ A payment link is a URL that allows users to complete a payment quickly and easi
                           "documentType": "CC"
                       }
                   }
-                ]
+                ],
+                "isGeneric": false
             }
             ```
             ```json {{ title: '401' }}

--- a/src/pages/payment-links/api/reference/payment-links.mdx
+++ b/src/pages/payment-links/api/reference/payment-links.mdx
@@ -17,7 +17,7 @@ Un link de pago es una URL que permite a los usuarios completar un pago de forma
 <Row>
     <Col>
 
-        Este endpoint permite crear un link de pago y configurarlo de acuerdo a tus necesidades
+        Este endpoint permite crear un link de pago y configurarlo de acuerdo a tus necesidades.
 
         <ApiReader
             path="/api/payment-link"
@@ -264,7 +264,8 @@ Un link de pago es una URL que permite a los usuarios completar un pago de forma
                       "documentType": "CC"
                     }
                   }
-                ]
+                ],
+                "isGeneric": false
             }
             ```
             ```json {{ title: '401' }}


### PR DESCRIPTION
Actualizar la documentación de la API de Link de pagos, agregando el nuevo campo de configuración `isGeneric`. 