### PR TITLE
docs: add auditor role description in self-declarations documentation

### DIFF
--- a/src/pages/en/selfdeclarations/content.mdx
+++ b/src/pages/en/selfdeclarations/content.mdx
@@ -6,5 +6,8 @@ In this module, you will find relevant information for any software user. It exp
 ## Administrator:
 Administrators are the users who can configure the system modules, create users, grant permissions, and generally manage the application. This manual provides all the information that will help administrators use the tool, create new users, determine tax return parameters, and more. It also explains the system's basic features.
 
+## Auditor:
+The auditor is the user responsible for reviewing and supervising the information within the system. Although they access the system through the same link as the administrator user, their permissions are restricted exclusively to reading and viewing. Their main function is to ensure control and monitoring of the information without intervening in its modification. To create a user with the auditor role, the system administrator must configure the corresponding permissions. To learn how to configure this role, click here : [Role Configuration.](/selfdeclarations/admin-user/actions#security)
+
 ## Declarant:
 The declarant is one of the most important roles in the system, as they are the user who creates, authorizes, declares, and pays taxes. All the functions and relevant information are explained here so that taxpayers can correctly manage and understand how the application works.

--- a/src/pages/selfdeclarations/content.mdx
+++ b/src/pages/selfdeclarations/content.mdx
@@ -6,5 +6,8 @@ En este módulo encontrará información relevante para cualquier usuario del so
 ## Administrador:
 Los administradores, son los usuarios que podrán configurar los módulos del sistema, crear usuarios, otorgar permisos y administrar el aplicativo de forma general. En este manual encontrará toda la información que le ayudará al administrador a usar la herramienta, crear otros usuarios, determinar los parámetros para la declaración, entre otros. Además se explican las funcionalidades básicas del sistema.
 
+## Auditor:
+El auditor es el usuario encargado de revisar y supervisar la información dentro del sistema. Aunque ingresa por el mismo enlace de acceso del usuario administrador, sus permisos están restringidos únicamente a lectura y visualización. Su función principal es garantizar el control y seguimiento de la información, sin intervenir en su modificación. Para crear un usuario con rol de auditor, es necesario que el administrador del sistema configure los permisos correspondientes. Para conocer cómo configurar éste rol, ingrese aquí: [Configuración de Roles.](/selfdeclarations/admin-user/actions#seguridad)
+
 ## Declarante:
 El declarante es uno de los roles más importantes del sistema, ya que es el usuario que crea, autoriza, declara y paga los impuestos. Aquí se explican todas las funciones e información relevante para que los declarantes manejen correctamente y entiendan el funcionamiento del aplicativo.


### PR DESCRIPTION
This update adds the description of the Auditor role in the self-declarations manual.