### PR TITLE
feat: Add the `id` property to the token creation response

### DIFF
--- a/src/assets/apis/gateway/en.yaml
+++ b/src/assets/apis/gateway/en.yaml
@@ -3205,7 +3205,7 @@ components:
       properties:
         id:
           type: "number"
-          description: "Tokenization identifier"
+          description: "Token identifier in the system; this only applies if the site has a configured token notification URL."
         token:
           type: "string"
           maxLength: "64"

--- a/src/assets/apis/gateway/en.yaml
+++ b/src/assets/apis/gateway/en.yaml
@@ -3203,6 +3203,9 @@ components:
 
         For output if all data is returned when tokenizing."
       properties:
+        id:
+          type: "number"
+          description: "Tokenization identifier"
         token:
           type: "string"
           maxLength: "64"

--- a/src/assets/apis/gateway/es.yaml
+++ b/src/assets/apis/gateway/es.yaml
@@ -3041,7 +3041,7 @@ es variable de acuerdo a la solicitud que se genere, cada servicio requiere que 
       properties:
         id:
           type: "number"
-          description: "Identificador del token en el sistema"
+          description: "Identificador del token en el sistema, aplica solo si el sitio cuenta con URL de notificación para token configurada"
         token:
           type: "string"
           maxLength: "64"

--- a/src/assets/apis/gateway/es.yaml
+++ b/src/assets/apis/gateway/es.yaml
@@ -3039,6 +3039,9 @@ es variable de acuerdo a la solicitud que se genere, cada servicio requiere que 
         Para la salida si se devuelven todos los datos al tokenizar
         "
       properties:
+        id:
+          type: "number"
+          description: "Identificador del token en el sistema"
         token:
           type: "string"
           maxLength: "64"

--- a/src/pages/en/gateway/api/reference/tokenize.mdx
+++ b/src/pages/en/gateway/api/reference/tokenize.mdx
@@ -133,6 +133,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/tokenize \
     "provider": "CREDIBANCO",
     "instrument": {
         "token": {
+            "id": 123,
             "token": "faketoken12f233bd8f5d42138d681bf07ea8295429df07a4af287703e30c891",
             "subtoken": "fakesubtoken00005",
             "franchise": "master",

--- a/src/pages/gateway/api/reference/tokenize.mdx
+++ b/src/pages/gateway/api/reference/tokenize.mdx
@@ -133,6 +133,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/tokenize \
     "provider": "CREDIBANCO",
     "instrument": {
         "token": {
+            "id": 123,
             "token": "faketoken12f233bd8f5d42138d681bf07ea8295429df07a4af287703e30c891",
             "subtoken": "fakesubtoken00005",
             "franchise": "master",


### PR DESCRIPTION
Add the `instrument.token.ID` property to the token creation endpoint for the Gateway API.