### PR TITLE
feat: Add parameter `id` to token search endpoint

### DIFF
--- a/src/assets/apis/gateway/en.yaml
+++ b/src/assets/apis/gateway/en.yaml
@@ -2906,6 +2906,9 @@ paths:
                       type: "object"
                       description: "Structure containing the tokenization information to be searched."
                       properties:
+                        id:
+                          type: "number"
+                          description: "Token identifier in the system."
                         token:
                           type: "string"
                           description: "Code generated to identify the card in the system."

--- a/src/assets/apis/gateway/es.yaml
+++ b/src/assets/apis/gateway/es.yaml
@@ -2739,6 +2739,9 @@ paths:
                       type: "object"
                       description: "Estructura que contiene la información de la tokenización a buscar."
                       properties:
+                        id:
+                          type: "number"
+                          description: "Identificador del token en el sistema."
                         token:
                           type: "string"
                           description: "Código generado para identificar la tarjeta en el sistema."

--- a/src/pages/en/gateway/api/reference/tokenize.mdx
+++ b/src/pages/en/gateway/api/reference/tokenize.mdx
@@ -252,6 +252,25 @@ curl -X "POST" https://api-co-dev.placetopay.ws/invalidate \
 
     <Col sticky>
         <CodeGroup title="Request" tag="POST" label="/gateway/token">
+```bash {{ title: 'ID' }}
+curl -X "POST" https://api-co-dev.placetopay.ws/gateway/token \
+-H "Content-Type: application/json" \
+-d '{
+    "locale": "es_CO",
+    "auth": {
+        "login":"aabbccdd1234567890aabbccdd123456",
+        "tranKey":"ABC123example456trankey+789abc012def3456ABC=",
+        "nonce":"NjE0OWVkODgwYjNhNw==",
+        "seed":"2021-09-21T09:34:48-05:00"
+    },
+    "instrument": {
+        "token": {
+            "id": 123,
+        }
+    }
+}'
+```
+
 
 ```bash {{ title: 'Token' }}
 curl -X "POST" https://api-co-dev.placetopay.ws/gateway/token \
@@ -304,6 +323,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/token \
     },
     "instrument": {
         "token": {
+            "id": 123,
             "token": "faketoken12f233bd8f5d42138d681bf07ea8295429df07a4af287703e30c891",
             "subtoken": "fakesubtoken00005"
         }

--- a/src/pages/gateway/api/reference/tokenize.mdx
+++ b/src/pages/gateway/api/reference/tokenize.mdx
@@ -251,6 +251,26 @@ curl -X "POST" https://api-co-dev.placetopay.ws/invalidate \
 
     <Col sticky>
         <CodeGroup title="Solicitud" tag="POST" label="/gateway/token">
+```bash {{ title: 'ID' }}
+curl -X "POST" https://api-co-dev.placetopay.ws/gateway/token \
+-H "Content-Type: application/json" \
+-d '{
+    "locale": "es_CO",
+    "auth": {
+        "login":"aabbccdd1234567890aabbccdd123456",
+        "tranKey":"ABC123example456trankey+789abc012def3456ABC=",
+        "nonce":"NjE0OWVkODgwYjNhNw==",
+        "seed":"2021-09-21T09:34:48-05:00"
+    },
+    "instrument": {
+        "token": {
+            "id": 123,
+        }
+    }
+}'
+```
+
+
 ```bash {{ title: 'Token' }}
 curl -X "POST" https://api-co-dev.placetopay.ws/gateway/token \
 -H "Content-Type: application/json" \
@@ -302,6 +322,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/token \
     },
     "instrument": {
         "token": {
+            "id": 123,
             "token": "faketoken12f233bd8f5d42138d681bf07ea8295429df07a4af287703e30c891",
             "subtoken": "fakesubtoken00005"
         }


### PR DESCRIPTION
Add the `instrument.token.id` property to the token search endpoint for the Gateway API.