### PR TITLE
feat: add requiresConfirmation to metadataand examples

### DIFF
--- a/src/assets/apis/gateway/en.yaml
+++ b/src/assets/apis/gateway/en.yaml
@@ -741,6 +741,10 @@ paths:
                       example: 2
                     kount:
                       $ref: '../base/en.yaml#/components/schemas/KountMetadata'
+                    requiresConfirmation:
+                      type: "boolean"
+                      description: "Indicates whether the transaction requires confirmation prior to processing."
+                      example: true
                 idempotenceKey:
                   type: "string"
                   description: "Unique key to identify the transaction. See more at [Idempotency control](/en/gateway/idempotency)"

--- a/src/assets/apis/gateway/es.yaml
+++ b/src/assets/apis/gateway/es.yaml
@@ -741,6 +741,10 @@ paths:
                       example: 2
                     kount:
                       $ref: '../base/es.yaml#/components/schemas/KountMetadata'
+                    requiresConfirmation:
+                      type: "boolean"
+                      description: "Indica si la transacción requiere confirmación previo a su procesamiento."
+                      example: true
                 idempotenceKey:
                   type: "string"
                   description: "Clave única para identificar la transacción. Ver más en [Control de Idempotencia](/gateway/idempotency)"

--- a/src/components/AdditionalDataExamples.jsx
+++ b/src/components/AdditionalDataExamples.jsx
@@ -186,6 +186,14 @@ const examples = [
             en: "Indicates whether a declined or failed transaction is eligible for reprocessing with an alternative payment method."
         }
     },
+    {
+        key: "requiresConfirmation",
+        example: "true",
+        description: {
+            es: "Indica si una transacción requiere ser confirmada previo a su procesamiento.",
+            en: "Indicates whether a transaction requires confirmation before processing."
+        }
+    },
   ];
 
 export function AdditionalDataExamples({extraExamples}) {

--- a/src/pages/en/gateway/api/reference/transaction.mdx
+++ b/src/pages/en/gateway/api/reference/transaction.mdx
@@ -857,6 +857,46 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
     "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
 }'
 ```
+```bash {{ title: 'Pending Confirmation' }}
+curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
+-H "Content-Type: application/json" \
+-d '{
+    "auth": {
+        "login": "aabbccdd1234567890aabbccdd123456",
+        "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+        "nonce": "NjBhZTllMjZjYmQxYg==",
+        "seed": "2021-05-26T14:14:46-05:00"
+    },
+    "payer": {
+        "name": "Ms. Nelle Beahan DVM",
+        "surname": "Spencer",
+        "email": "gsteuber@kling.com",
+        "documentType": "CC",
+        "document": "3303562321",
+        "mobile": "3906523321"
+    },
+    "payment": {
+        "reference": "TEST_20210526_141005",
+        "description": "Cum vitae et consequatur quas adipisci ut rem.",
+        "amount": {
+            "currency": "USD",
+            "total": 100
+        }
+    },
+    "instrument": {
+        "card": {
+            "number": "44111111111111111",
+            "expiration": "12/30",
+            "cvv": "123",
+        }
+    },
+    "Metadata": {
+        "requiresConfirmation": true
+    },
+    "ipAddress": "190.85.90.130",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
+}'
+```
         </CodeGroup>
     </Col>
 </Row>
@@ -1656,6 +1696,69 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
                 }
             }
         }
+        ```
+        ```json {{ title: 'Pending Confirmation'}}
+            {
+                "status": {
+                    "status": "PENDING_CONFIRMATION",
+                    "reason": "?!",
+                    "message": "Transaction pending confirmation",
+                    "date": "2026-05-22T23:40:06-05:00"
+                },
+                "date": "2026-05-22T23:40:06-05:00",
+                "transactionDate": "2026-05-22T23:40:06-05:00",
+                "internalReference": 41,
+                "reference": "PY-BR-TP",
+                "paymentMethod": "PS_VS",
+                "franchise": "visa",
+                "franchiseName": "Visa",
+                "issuerName": "BANCO DE GUAYAQUIL, S.A.",
+                "amount": {
+                    "taxes": [
+                    {
+                        "kind": "airportTax",
+                        "amount": 63,
+                        "base": 0
+                    },
+                    {
+                        "kind": "valueAddedTax",
+                        "amount": 158.47,
+                        "base": 0
+                    }
+                    ],
+                    "currency": "USD",
+                    "total": 1161.12
+                },
+                "conversion": {
+                    "from": {
+                    "currency": "USD",
+                    "total": 1161.12
+                    },
+                    "to": {
+                    "currency": "USD",
+                    "total": 1161
+                    },
+                    "factor": 1
+                },
+                "authorization": "000000",
+                "type": "AUTH_ONLY",
+                "receipt": null,
+                "refunded": false,
+                "lastDigits": "1111",
+                "provider": "PAYSTUDIO",
+                "discount": null,
+                "processorFields": {
+                    "id": "08c0284b20510c8db8dcb29137374718",
+                    "b24": "?!"
+                },
+                "additional": {
+                    "merchantCode": "123456",
+                    "terminalNumber": "12345678",
+                    "bin": "411111",
+                    "cardType": "R",
+                    "installments": 1
+                }
+            }
         ```
 
         ```json {{ title: 'Rejected Error' }}

--- a/src/pages/en/gateway/api/reference/transaction.mdx
+++ b/src/pages/en/gateway/api/reference/transaction.mdx
@@ -890,7 +890,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
             "cvv": "123",
         }
     },
-    "Metadata": {
+    "metadata": {
         "requiresConfirmation": true
     },
     "ipAddress": "190.85.90.130",
@@ -1697,7 +1697,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
             }
         }
         ```
-        ```json {{ title: 'Pending Confirmation'}}
+        ```json {{ title: 'Requires Confirmation'}}
             {
                 "status": {
                     "status": "PENDING_CONFIRMATION",

--- a/src/pages/gateway/api/reference/transaction.mdx
+++ b/src/pages/gateway/api/reference/transaction.mdx
@@ -860,7 +860,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/process \
     "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
 }'
 ```
-```bash {{ title: 'Pendiente de confirmación' }}
+```bash {{ title: 'Requiere confirmación' }}
 curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
 -H "Content-Type: application/json" \
 -d '{
@@ -893,7 +893,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
             "cvv": "123",
         }
     },
-    "Metadata": {
+    "metadata": {
         "requiresConfirmation": true
     },
     "ipAddress": "190.85.90.130",
@@ -1700,7 +1700,7 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
             }
         }
         ```
-        ```json {{ title: 'Pending Confirmation'}}
+        ```json {{ title: 'Pendiente de Confirmación'}}
             {
                 "status": {
                     "status": "PENDING_CONFIRMATION",

--- a/src/pages/gateway/api/reference/transaction.mdx
+++ b/src/pages/gateway/api/reference/transaction.mdx
@@ -860,7 +860,46 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/process \
     "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
 }'
 ```
-
+```bash {{ title: 'Pendiente de confirmación' }}
+curl -X "POST" https://api-co-dev.placetopay.ws/gateway/information \
+-H "Content-Type: application/json" \
+-d '{
+    "auth": {
+        "login": "aabbccdd1234567890aabbccdd123456",
+        "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+        "nonce": "NjBhZTllMjZjYmQxYg==",
+        "seed": "2021-05-26T14:14:46-05:00"
+    },
+    "payer": {
+        "name": "Ms. Nelle Beahan DVM",
+        "surname": "Spencer",
+        "email": "gsteuber@kling.com",
+        "documentType": "CC",
+        "document": "3303562321",
+        "mobile": "3906523321"
+    },
+    "payment": {
+        "reference": "TEST_20210526_141005",
+        "description": "Cum vitae et consequatur quas adipisci ut rem.",
+        "amount": {
+            "currency": "USD",
+            "total": 100
+        }
+    },
+    "instrument": {
+        "card": {
+            "number": "44111111111111111",
+            "expiration": "12/30",
+            "cvv": "123",
+        }
+    },
+    "Metadata": {
+        "requiresConfirmation": true
+    },
+    "ipAddress": "190.85.90.130",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36"
+}'
+```
         </CodeGroup>
     </Col>
 </Row>
@@ -1660,6 +1699,69 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/process \
                 }
             }
         }
+        ```
+        ```json {{ title: 'Pending Confirmation'}}
+            {
+                "status": {
+                    "status": "PENDING_CONFIRMATION",
+                    "reason": "?!",
+                    "message": "Transacción pendiente de confirmación",
+                    "date": "2026-05-22T23:40:06-05:00"
+                },
+                "date": "2026-05-22T23:40:06-05:00",
+                "transactionDate": "2026-05-22T23:40:06-05:00",
+                "internalReference": 41,
+                "reference": "PY-BR-TP",
+                "paymentMethod": "PS_VS",
+                "franchise": "visa",
+                "franchiseName": "Visa",
+                "issuerName": "BANCO DE GUAYAQUIL, S.A.",
+                "amount": {
+                    "taxes": [
+                    {
+                        "kind": "airportTax",
+                        "amount": 63,
+                        "base": 0
+                    },
+                    {
+                        "kind": "valueAddedTax",
+                        "amount": 158.47,
+                        "base": 0
+                    }
+                    ],
+                    "currency": "USD",
+                    "total": 1161.12
+                },
+                "conversion": {
+                    "from": {
+                    "currency": "USD",
+                    "total": 1161.12
+                    },
+                    "to": {
+                    "currency": "USD",
+                    "total": 1161
+                    },
+                    "factor": 1
+                },
+                "authorization": "000000",
+                "type": "AUTH_ONLY",
+                "receipt": null,
+                "refunded": false,
+                "lastDigits": "1111",
+                "provider": "PAYSTUDIO",
+                "discount": null,
+                "processorFields": {
+                    "id": "08c0284b20510c8db8dcb29137374718",
+                    "b24": "?!"
+                },
+                "additional": {
+                    "merchantCode": "123456",
+                    "terminalNumber": "12345678",
+                    "bin": "411111",
+                    "cardType": "R",
+                    "installments": 1
+                }
+            }
         ```
 
         ```json {{ title: 'Error Rechazada' }}


### PR DESCRIPTION
Add requiresConfirmation flag to metadata and examples for request and response in gateway-process