### PR TITLE
Feature/wc docs peding confirmation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "build": "NODE_OPTIONS=\"--max-old-space-size=8192\" next build --webpack",
     "build:windows": "set NODE_OPTIONS=--max-old-space-size=8192 && next build --webpack",
     "start": "npx serve@latest out",

--- a/src/assets/apis/checkout/en.yaml
+++ b/src/assets/apis/checkout/en.yaml
@@ -791,6 +791,52 @@ paths:
                         internalReference: 421694
                         paymentMethodName: Visa
                     subscription: null
+                Pending Confirmation:
+                  value:
+                    requestId: 1
+                    status:
+                      status: PENDING
+                      reason: PT
+                      message: The petition is pending
+                      date: '2025-01-21T21:20:07-05:00'
+                    request:
+                      locale: es_CO
+                      payment:
+                        reference: 'TEST_VISA'
+                        description: Test payment
+                        amount:
+                          currency: USD
+                          total: 100
+                      metadata:
+                        requiresConfirmation: true
+                      returnUrl: 'https://merchant.com/return'
+                      ipAddress: 127.0.0.1
+                      userAgent: Placetopay Sandbox
+                      expiration: '2026-12-30T00:00:00-05:00'
+                    payment:
+                      - status:
+                          status: PENDING_CONFIRMATION
+                          reason: PT
+                          message: Pending confirmation transaction
+                          date: '2025-01-21T21:20:07-05:00'
+                        internalReference: 84
+                        paymentMethod: visa
+                        paymentMethodName: Visa
+                        issuerName: 'JPMORGAN CHASE BANK, N.A.'
+                        amount:
+                          from:
+                            currency: USD
+                            total: 100
+                          to:
+                            currency: USD
+                            total: 100
+                          factor: 1
+                        authorization: '000000'
+                        reference: 'TEST_VISA'
+                        receipt: '426882'
+                        franchise: CR_VS
+                        refunded: false
+                    subscription: null
       description: |
         Obtiene la información de la sesión, si en la sesión hay transacciones se muestra el detalle de las mismas.
       requestBody:
@@ -1276,7 +1322,98 @@ paths:
                       receipt: '499435368733'
                       franchise: PS_VS
                       refunded: false
-      description: 'Permite realizar operaciones básicas de preauthorización como `checkout`, `reauthorization`, (No aplica para Puerto Rico)  por otro lado también permite revertir un pago aprobado con el código de referencia interna `reverse`.'
+                Confirm:
+                  value:
+                    status:
+                      status: APPROVED
+                      reason: '00'
+                      message: Aprobada
+                      date: '2025-01-21T21:20:07-05:00'
+                    payment:
+                      status:
+                        status: APPROVED
+                        reason: '00'
+                        message: Aprobada
+                        date: '2025-01-21T21:20:07-05:00'
+                      internalReference: 84
+                      paymentMethod: visa
+                      paymentMethodName: Visa
+                      issuerName: 'JPMORGAN CHASE BANK, N.A.'
+                      amount:
+                        from:
+                          currency: USD
+                          total: 100
+                        to:
+                          currency: USD
+                          total: 100
+                        factor: 1
+                      authorization: '000000'
+                      reference: 'TEST_VISA'
+                      receipt: '426882'
+                      franchise: CR_VS
+                      refunded: false
+                Cancel:
+                  value:
+                    status:
+                      status: REJECTED
+                      reason: '?C'
+                      message: Cancelada por el comercio
+                      date: '2025-01-21T21:20:07-05:00'
+                    payment:
+                      status:
+                        status: REJECTED
+                        reason: '?C'
+                        message: Cancelada por el comercio
+                        date: '2025-01-21T21:20:07-05:00'
+                      internalReference: 84
+                      paymentMethod: visa
+                      paymentMethodName: Visa
+                      issuerName: 'JPMORGAN CHASE BANK, N.A.'
+                      amount:
+                        from:
+                          currency: USD
+                          total: 100
+                        to:
+                          currency: USD
+                          total: 100
+                        factor: 1
+                      authorization: '000000'
+                      reference: 'TEST_VISA'
+                      receipt: '426882'
+                      franchise: CR_VS
+                      refunded: false
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/Status'
+              examples:
+                SessionNotSupported:
+                  value:
+                    status:
+                      status: FAILED
+                      reason: request_not_valid
+                      message: La acción [confirm] no está soportada para esta sesión
+                      date: '2025-01-21T21:20:07-05:00'
+                InvalidTransactionState:
+                  value:
+                    status:
+                      status: FAILED
+                      reason: request_not_valid
+                      message: La acción [confirm] solo está disponible para transacciones en estado pendiente de confirmación
+                      date: '2025-01-21T21:20:07-05:00'
+                ServiceUnavailable:
+                  value:
+                    status:
+                      status: FAILED
+                      reason: transaction_request_error
+                      message: La transacción ya ha sido expirada
+                      date: '2025-01-21T21:20:07-05:00'
+      description: 'Permite realizar operaciones básicas de preauthorización como `checkout`, `reauthorization`, (No aplica para Puerto Rico). También permite confirmar (`confirm`) o cancelar (`cancel`) transacciones en estado PENDING_CONFIRMATION, y revertir un pago aprobado con `reverse`.'
       requestBody:
         content:
           application/json:
@@ -1316,6 +1453,24 @@ paths:
                     seed: '2021-09-21T09:34:48-05:00'
                   internalReference: 123
                   action: reverse
+              Confirm:
+                value:
+                  auth:
+                    login: aabbccdd1234567890aabbccdd123456
+                    tranKey: ABC123example456trankey+789abc012def3456ABC=
+                    nonce: NjE0OWVkODgwYjNhNw==
+                    seed: '2021-09-21T09:34:48-05:00'
+                  internalReference: 84
+                  action: confirm
+              Cancel:
+                value:
+                  auth:
+                    login: aabbccdd1234567890aabbccdd123456
+                    tranKey: ABC123example456trankey+789abc012def3456ABC=
+                    nonce: NjE0OWVkODgwYjNhNw==
+                    seed: '2021-09-21T09:34:48-05:00'
+                  internalReference: 84
+                  action: cancel
         description: ''
       x-internal: false
   /api/instrument/invalidate:
@@ -1866,7 +2021,7 @@ components:
         - reference
         - description
       description: |
-        [Beta] Detail of the autopay to be generated. The user must register a payment method so that automatic charges are made on that payment method according to the agreed conditions. Required when `.type` is `autopay`.
+        Detail of the autopay to be generated. The user must register a payment method so that automatic charges are made on that payment method according to the agreed conditions. Required when `.type` is `autopay`.
       properties:
         action:
           type: enum
@@ -2195,6 +2350,7 @@ components:
           enum:
             - APPROVED
             - PENDING
+            - PENDING_CONFIRMATION
             - REJECTED
             - APPROVED_PARTIAL
             - PARTIAL_EXPIRED
@@ -2823,7 +2979,7 @@ components:
     TransactionActionRequest:
       title: TransactionActionRequest
       type: object
-      description: 'Structure that allows for preauthorization requests such as `checkout`, `reauthorization` and `reverse`'
+      description: 'Structure that allows performing preauthorization requests such as `checkout`, `reauthorization`, `reverse`, `confirm` and `cancel`'
       x-examples:
         checkout example:
           internalReference: 1
@@ -2840,6 +2996,12 @@ components:
         reverse example:
           internalReference: 1
           action: reverse
+        confirm example:
+          internalReference: 1
+          action: confirm
+        cancel example:
+          internalReference: 1
+          action: cancel
       examples: []
       required:
         - auth
@@ -2853,14 +3015,18 @@ components:
             - enum
           description: |
             Type of operation to perform on the transaction
-            
+
             `reverse` to reverse a transaction.
             `reauthorization` to modify a checkin transaction.
             `checkout` to close and collect a checkin transaction.
+            `confirm` to confirm a transaction in PENDING_CONFIRMATION state.
+            `cancel` to cancel a transaction in PENDING_CONFIRMATION state.
           enum:
             - checkout
             - reauthorization
             - reverse
+            - confirm
+            - cancel
           example: checkout
         internalReference:
           $ref: '#/components/schemas/InternalReference'
@@ -3672,6 +3838,13 @@ components:
           description: "Beneficiary ID linked to the receiving account in a PSE transaction. Required for merchants in the “Financial Services” category"
         kount:
           $ref: '../base/en.yaml#/components/schemas/KountMetadata'
+        requiresConfirmation:
+          type: "boolean"
+          description: |
+            Indicates whether the transaction requires merchant confirmation before final processing.
+            When set to `true`, the transaction will be created in PENDING_CONFIRMATION state
+            and the merchant must call confirm or cancel via the transaction actions endpoint.
+          example: true
   securitySchemes: {}
   responses:
     StatusResponse:

--- a/src/assets/apis/checkout/es.yaml
+++ b/src/assets/apis/checkout/es.yaml
@@ -791,6 +791,52 @@ paths:
                         internalReference: 421694
                         paymentMethodName: Visa
                     subscription: null
+                Pendiente de Confirmación:
+                  value:
+                    requestId: 1
+                    status:
+                      status: PENDING
+                      reason: PT
+                      message: La petición se encuentra pendiente
+                      date: '2025-01-21T21:20:07-05:00'
+                    request:
+                      locale: es_CO
+                      payment:
+                        reference: 'TEST_VISA'
+                        description: Pago de prueba
+                        amount:
+                          currency: USD
+                          total: 100
+                      metadata:
+                        requiresConfirmation: true
+                      returnUrl: 'https://comercio.com/retorno'
+                      ipAddress: 127.0.0.1
+                      userAgent: Placetopay Sandbox
+                      expiration: '2026-12-30T00:00:00-05:00'
+                    payment:
+                      - status:
+                          status: PENDING_CONFIRMATION
+                          reason: PT
+                          message: Transacción pendiente de confirmación
+                          date: '2025-01-21T21:20:07-05:00'
+                        internalReference: 84
+                        paymentMethod: visa
+                        paymentMethodName: Visa
+                        issuerName: 'JPMORGAN CHASE BANK, N.A.'
+                        amount:
+                          from:
+                            currency: USD
+                            total: 100
+                          to:
+                            currency: USD
+                            total: 100
+                          factor: 1
+                        authorization: '000000'
+                        reference: 'TEST_VISA'
+                        receipt: '426882'
+                        franchise: CR_VS
+                        refunded: false
+                    subscription: null
       description: |
         Obtiene la información de la sesión, si en la sesión hay transacciones se muestra el detalle de las mismas.
       requestBody:
@@ -1276,7 +1322,98 @@ paths:
                       receipt: '499435368733'
                       franchise: PS_VS
                       refunded: false
-      description: 'Permite realizar operaciones básicas de preauthorización como `checkout`, `reauthorization`, (No aplica para Puerto Rico)  por otro lado también permite revertir un pago aprobado con el código de referencia interna `reverse`.'
+                Confirmar:
+                  value:
+                    status:
+                      status: APPROVED
+                      reason: '00'
+                      message: Aprobada
+                      date: '2025-01-21T21:20:07-05:00'
+                    payment:
+                      status:
+                        status: APPROVED
+                        reason: '00'
+                        message: Aprobada
+                        date: '2025-01-21T21:20:07-05:00'
+                      internalReference: 84
+                      paymentMethod: visa
+                      paymentMethodName: Visa
+                      issuerName: 'JPMORGAN CHASE BANK, N.A.'
+                      amount:
+                        from:
+                          currency: USD
+                          total: 100
+                        to:
+                          currency: USD
+                          total: 100
+                        factor: 1
+                      authorization: '000000'
+                      reference: 'TEST_VISA'
+                      receipt: '426882'
+                      franchise: CR_VS
+                      refunded: false
+                Cancelar:
+                  value:
+                    status:
+                      status: REJECTED
+                      reason: '?C'
+                      message: Cancelada por el comercio
+                      date: '2025-01-21T21:20:07-05:00'
+                    payment:
+                      status:
+                        status: REJECTED
+                        reason: '?C'
+                        message: Cancelada por el comercio
+                        date: '2025-01-21T21:20:07-05:00'
+                      internalReference: 84
+                      paymentMethod: visa
+                      paymentMethodName: Visa
+                      issuerName: 'JPMORGAN CHASE BANK, N.A.'
+                      amount:
+                        from:
+                          currency: USD
+                          total: 100
+                        to:
+                          currency: USD
+                          total: 100
+                        factor: 1
+                      authorization: '000000'
+                      reference: 'TEST_VISA'
+                      receipt: '426882'
+                      franchise: CR_VS
+                      refunded: false
+        '400':
+          description: Solicitud inválida
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/Status'
+              examples:
+                SesiónNoSoportada:
+                  value:
+                    status:
+                      status: FAILED
+                      reason: request_not_valid
+                      message: La acción [confirm] no está soportada para esta sesión
+                      date: '2025-01-21T21:20:07-05:00'
+                TransacciónNoPendienteConfirmación:
+                  value:
+                    status:
+                      status: FAILED
+                      reason: request_not_valid
+                      message: La acción [confirm] solo está disponible para transacciones en estado pendiente de confirmación
+                      date: '2025-01-21T21:20:07-05:00'
+                ServicioNoDisponible:
+                  value:
+                    status:
+                      status: FAILED
+                      reason: transaction_request_error
+                      message: La transacción ya ha sido expirada
+                      date: '2025-01-21T21:20:07-05:00'
+      description: 'Permite realizar operaciones básicas de preauthorización como `checkout`, `reauthorization`, (No aplica para Puerto Rico). También permite confirmar (`confirm`) o cancelar (`cancel`) transacciones en estado PENDING_CONFIRMATION, y revertir un pago aprobado con `reverse`.'
       requestBody:
         content:
           application/json:
@@ -1316,6 +1453,24 @@ paths:
                     seed: '2021-09-21T09:34:48-05:00'
                   internalReference: 123
                   action: reverse
+              Confirmar:
+                value:
+                  auth:
+                    login: aabbccdd1234567890aabbccdd123456
+                    tranKey: ABC123example456trankey+789abc012def3456ABC=
+                    nonce: NjE0OWVkODgwYjNhNw==
+                    seed: '2021-09-21T09:34:48-05:00'
+                  internalReference: 84
+                  action: confirm
+              Cancelar:
+                value:
+                  auth:
+                    login: aabbccdd1234567890aabbccdd123456
+                    tranKey: ABC123example456trankey+789abc012def3456ABC=
+                    nonce: NjE0OWVkODgwYjNhNw==
+                    seed: '2021-09-21T09:34:48-05:00'
+                  internalReference: 84
+                  action: cancel
         description: ''
       x-internal: false
   /api/instrument/invalidate:
@@ -1859,7 +2014,7 @@ components:
         - reference
         - description
       description: |
-        [BETA] Detalle del autopago a generar. El usuario debe registrar un medio de pago para que se realicen cobros automáticos sobre ese medio de pago segun las condiciones pactadas. Es requerido cuando `type` es `autopay`.
+        Detalle del autopago a generar. El usuario debe registrar un medio de pago para que se realicen cobros automáticos sobre ese medio de pago segun las condiciones pactadas. Es requerido cuando `type` es `autopay`.
       properties:
         action:
           type: enum
@@ -2191,6 +2346,7 @@ components:
           enum:
             - APPROVED
             - PENDING
+            - PENDING_CONFIRMATION
             - REJECTED
             - APPROVED_PARTIAL
             - PARTIAL_EXPIRED
@@ -2904,7 +3060,7 @@ components:
     TransactionActionRequest:
       title: TransactionActionRequest
       type: object
-      description: 'Estructura que permite realizar solicitudes de preauthorización como `checkout`, `reauthorization` y `reverse`'
+      description: 'Estructura que permite realizar solicitudes de preauthorización como `checkout`, `reauthorization`, `reverse`, `confirm` y `cancel`'
       x-examples:
         checkout example:
           internalReference: 1
@@ -2921,6 +3077,12 @@ components:
         reverse example:
           internalReference: 1
           action: reverse
+        confirm example:
+          internalReference: 1
+          action: confirm
+        cancel example:
+          internalReference: 1
+          action: cancel
       examples: []
       required:
         - auth
@@ -2934,14 +3096,18 @@ components:
             - enum
           description: |
             Tipo de operación a realizar sobre la transacción
-            
-            `reverse` para reembolsar una transacción.   
-            `reauthorization` para modificar una transacción de checkin.   
+
+            `reverse` para reembolsar una transacción.
+            `reauthorization` para modificar una transacción de checkin.
             `checkout` para cerrar y cobrar una transacción de checkin.
+            `confirm` para confirmar una transacción en estado PENDING_CONFIRMATION.
+            `cancel` para cancelar una transacción en estado PENDING_CONFIRMATION.
           enum:
             - checkout
             - reauthorization
             - reverse
+            - confirm
+            - cancel
           example: checkout
         internalReference:
           $ref: '#/components/schemas/InternalReference'
@@ -3749,6 +3915,13 @@ components:
             description: "ID del beneficiario asociado a la cuenta receptora en una transacción PSE. Requerido para comercios con categoría “Servicios Financieros"
         kount:
           $ref: '../base/es.yaml#/components/schemas/KountMetadata'
+        requiresConfirmation:
+          type: "boolean"
+          description: |
+            Indica si la transacción requiere confirmación del comercio previo a su procesamiento final.
+            Cuando se establece en `true`, la transacción se creará en estado PENDING_CONFIRMATION
+            y el comercio deberá llamar a confirm o cancel mediante el endpoint de acciones de transacción.
+          example: true
   securitySchemes: {}
   responses:
     StatusResponse:

--- a/src/components/react-flow/ConfirmationFlowStates.jsx
+++ b/src/components/react-flow/ConfirmationFlowStates.jsx
@@ -4,31 +4,32 @@ import {nodeTypes} from "@/components/react-flow/react-flow";
 const initialNodes = [
     { id: 'STATE_PENDING', type: 'tag', position: { x: 0, y: 0 }, data: { label: "Session", tagLabel: 'PENDING', tagColor: 'amber', targetHandle: false } },
 
-    { id: 'ACTION_T_PENDING_CONF', type: 'action', position: { x: 200, y: -20 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Requires Confirmation', rounded: true } },
+    { id: 'ACTION_T_PENDING_CONF', type: 'action', position: { x: 120, y: 14 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Captures Transaction', rounded: true } },
 
-    { id: 'STATE_PENDING_CONFIRMATION', type: 'tag', position: { x: 450, y: -20 }, data: { label: "Transaction", tagLabel: 'PENDING\\_CONFIRMATION', tagColor: 'amber', sourceHandle: true, targetHandle: true } },
+    { id: 'STATE_PENDING_2', type: 'tag', position: { x: 320, y: 0 }, data: { label: "Session", tagLabel: 'PENDING', tagColor: 'amber', sourceHandle: true, targetHandle: true } },
 
-    { id: 'ACTION_CONFIRM', type: 'action', position: { x: 700, y: -65 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Merchant Confirms', rounded: true } },
-    { id: 'ACTION_CANCEL', type: 'action', position: { x: 700, y: 25 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Merchant Cancels / Timeout', rounded: true } },
+    { id: 'ACTION_CONFIRM', type: 'action', position: { x: 450, y: -55 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Merchant Confirms', rounded: true } },
+    { id: 'ACTION_CANCEL', type: 'action', position: { x: 450, y: 80 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Merchant Cancels / Expiration', rounded: true } },
 
-    { id: 'STATE_APPROVED', type: 'tag', position: { x: 950, y: -65 }, data: { label: "Session", tagLabel: 'APPROVED', tagColor: 'primary', sourceHandle: false } },
-    { id: 'STATE_REJECTED', type: 'tag', position: { x: 950, y: 25 }, data: { label: "Session", tagLabel: 'REJECTED', tagColor: 'rose', sourceHandle: false } },
+    { id: 'STATE_APPROVED', type: 'tag', position: { x: 750, y: -80 }, data: { label: "Session", tagLabel: 'APPROVED', tagColor: 'primary', sourceHandle: false } },
+    { id: 'STATE_REJECTED', type: 'tag', position: { x: 750, y: 25 }, data: { label: "Session", tagLabel: 'REJECTED', tagColor: 'rose', sourceHandle: false } },
 ];
 
 const initialEdges = [
     { id: 'e__1', source: 'STATE_PENDING', target: 'ACTION_T_PENDING_CONF' },
-    { id: 'e__2', source: 'ACTION_T_PENDING_CONF', target: 'STATE_PENDING_CONFIRMATION' },
+    { id: 'e__2', source: 'ACTION_T_PENDING_CONF', target: 'STATE_PENDING_2' },
 
-    { id: 'e__3', source: 'STATE_PENDING_CONFIRMATION', target: 'ACTION_CONFIRM' },
-    { id: 'e__4', source: 'ACTION_CONFIRM', target: 'STATE_APPROVED' },
+    { id: 'e__4', source: 'STATE_PENDING_2', target: 'ACTION_CONFIRM' },
+    { id: 'e__5', source: 'ACTION_CONFIRM', target: 'STATE_APPROVED' },
+    { id: 'e__8', source: 'ACTION_CONFIRM', target: 'STATE_REJECTED' },
 
-    { id: 'e__5', source: 'STATE_PENDING_CONFIRMATION', target: 'ACTION_CANCEL' },
-    { id: 'e__6', source: 'ACTION_CANCEL', target: 'STATE_REJECTED' },
+    { id: 'e__6', source: 'STATE_PENDING_2', target: 'ACTION_CANCEL' },
+    { id: 'e__7', source: 'ACTION_CANCEL', target: 'STATE_REJECTED' },
 ];
 
 export default function ConfirmationFlowStates() {
     return (
-        <div style={{ width: '100%', height: '220px' }} className="overflow-auto ring-1 ring-gray-900/7.5 dark:ring-white/10 rounded-2xl nowheel">
+        <div style={{ width: '100%', height: '180px' }} className="overflow-auto ring-1 ring-gray-900/7.5 dark:ring-white/10 rounded-2xl nowheel">
             <ReactFlow
                 nodes={initialNodes}
                 edges={initialEdges}

--- a/src/components/react-flow/ConfirmationFlowStates.jsx
+++ b/src/components/react-flow/ConfirmationFlowStates.jsx
@@ -1,0 +1,45 @@
+import ReactFlow, {Background, Controls} from 'reactflow';
+import {nodeTypes} from "@/components/react-flow/react-flow";
+
+const initialNodes = [
+    { id: 'STATE_PENDING', type: 'tag', position: { x: 0, y: 0 }, data: { label: "Session", tagLabel: 'PENDING', tagColor: 'amber', targetHandle: false } },
+
+    { id: 'ACTION_T_PENDING_CONF', type: 'action', position: { x: 200, y: -20 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Requires Confirmation', rounded: true } },
+
+    { id: 'STATE_PENDING_CONFIRMATION', type: 'tag', position: { x: 450, y: -20 }, data: { label: "Transaction", tagLabel: 'PENDING\\_CONFIRMATION', tagColor: 'amber', sourceHandle: true, targetHandle: true } },
+
+    { id: 'ACTION_CONFIRM', type: 'action', position: { x: 700, y: -65 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Merchant Confirms', rounded: true } },
+    { id: 'ACTION_CANCEL', type: 'action', position: { x: 700, y: 25 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Merchant Cancels / Timeout', rounded: true } },
+
+    { id: 'STATE_APPROVED', type: 'tag', position: { x: 950, y: -65 }, data: { label: "Session", tagLabel: 'APPROVED', tagColor: 'primary', sourceHandle: false } },
+    { id: 'STATE_REJECTED', type: 'tag', position: { x: 950, y: 25 }, data: { label: "Session", tagLabel: 'REJECTED', tagColor: 'rose', sourceHandle: false } },
+];
+
+const initialEdges = [
+    { id: 'e__1', source: 'STATE_PENDING', target: 'ACTION_T_PENDING_CONF' },
+    { id: 'e__2', source: 'ACTION_T_PENDING_CONF', target: 'STATE_PENDING_CONFIRMATION' },
+
+    { id: 'e__3', source: 'STATE_PENDING_CONFIRMATION', target: 'ACTION_CONFIRM' },
+    { id: 'e__4', source: 'ACTION_CONFIRM', target: 'STATE_APPROVED' },
+
+    { id: 'e__5', source: 'STATE_PENDING_CONFIRMATION', target: 'ACTION_CANCEL' },
+    { id: 'e__6', source: 'ACTION_CANCEL', target: 'STATE_REJECTED' },
+];
+
+export default function ConfirmationFlowStates() {
+    return (
+        <div style={{ width: '100%', height: '220px' }} className="overflow-auto ring-1 ring-gray-900/7.5 dark:ring-white/10 rounded-2xl nowheel">
+            <ReactFlow
+                nodes={initialNodes}
+                edges={initialEdges}
+                nodeTypes={nodeTypes}
+                fitView
+                zoomOnScroll={false}
+                className="bg-gray-50 dark:bg-gray-800"
+            >
+                <Background variant="dots" gap={12} size={1} />
+                <Controls showInteractive={false} />
+            </ReactFlow>
+        </div>
+    );
+}

--- a/src/components/react-flow/SequenceDiagram/Diagrams/Checkout/ConfirmationIntegration.jsx
+++ b/src/components/react-flow/SequenceDiagram/Diagrams/Checkout/ConfirmationIntegration.jsx
@@ -1,0 +1,157 @@
+import SequenceDiagram from "@/components/react-flow/SequenceDiagram/SequenceDiagram"
+import SequenceActor from "@/components/react-flow/SequenceDiagram/SequenceActor"
+import SequenceAction from "@/components/react-flow/SequenceDiagram/SequenceAction"
+import Line from "@/components/react-flow/SequenceDiagram/Line"
+import { useLocale } from "@/components/LocaleProvider"
+
+const T = {
+  es: {
+    site: "Tu sitio",
+    server: "Tu servidor",
+    start: "Inicio",
+    initProcess: "Iniciar proceso",
+    createSession: `<span>Crear sesión con<br><b>requiresConfirmation: true</b></span>`,
+    returnSession: `<span>Retorna <b>requestId</b><br> y <b>processUrl</b></span>`,
+    redirect: `<span>Redireccionar usuario a <b>processUrl</b></span>`,
+    complete: `<span>Usuario completa<br> el proceso</span>`,
+    returnUrl: `<span>Retorna a url enviada en <br> <b>CreateSessionRequest.returnUrl</b></span>`,
+    query: "Consulta",
+    querySession: "Consultar sesión",
+    queryStatus: `<span>Retorna sesión <b>PENDING</b> <br>con transacción <b>PENDING_CONFIRMATION</b></span>`,
+    confirm: "Confirmar o Cancelar",
+    confirmAction: "Confirmar o cancelar transacción",
+    finalStatus: "Retornar estado final",
+    detail: "Detalle del proceso",
+  },
+  en: {
+    site: "Your site",
+    server: "Your server",
+    start: "Start",
+    initProcess: "Start process",
+    createSession: `<span>Create session with<br><b>requiresConfirmation: true</b></span>`,
+    returnSession: `<span>Returns <b>requestId</b><br> and <b>processUrl</b></span>`,
+    redirect: `<span>Redirect user to <b>processUrl</b></span>`,
+    complete: `<span>User completes<br> process</span>`,
+    returnUrl: `<span>Returns to url sent as <br> <b>CreateSessionRequest.returnUrl</b></span>`,
+    query: "Query",
+    querySession: "Query session",
+    queryStatus: `<span>Return session <b>PENDING</b> <br>with <b>PENDING_CONFIRMATION</b> transaction</span>`,
+    confirm: "Confirm or Cancel",
+    confirmAction: "Confirm or cancel transaction",
+    finalStatus: "Return final status",
+    detail: "Process detail",
+  },
+}
+
+export default function ConfirmationIntegration() {
+  const { locale } = useLocale()
+  const t = T[locale] ?? T.es
+
+  return (
+    <SequenceDiagram customView={{ height:730, x:120, y:27.2727 }}>
+    <SequenceActor 
+    id="site" 
+    color="bg-blueFlow"
+    label={t.site} 
+    positionX="0" 
+    positionY="0" 
+    height="780px" 
+    />
+    <Line id="lineInit" label={t.start} positionX="-100" positionY="35" width="800px" />
+    <SequenceActor id="server" label={t.server} positionX="220" positionY="0" height="780px" />
+    <SequenceActor id="webcheckout" color="bg-orangeFlow" label="Webcheckout" positionX="600" positionY="0" height="780px" />
+    <SequenceAction 
+        id="process"
+        from="site" 
+        to="server" 
+        message={t.initProcess}
+        positionX="50" 
+        positionY="70" 
+    />
+    <SequenceAction 
+        id="session"  
+        from="server" 
+        to="webcheckout" 
+        message={t.createSession}
+        positionX="300" 
+        positionY="70" 
+    />
+    <SequenceAction 
+        id="returnSesion"
+        from="webcheckout" 
+        to="server" 
+        positionX="330"
+        positionY="130"
+        message={t.returnSession}
+    />
+    <SequenceAction 
+        id="redirect"
+        from="server" 
+        to="webcheckout" 
+        positionX="280"
+        positionY="250"
+        message={t.redirect}
+    />
+    <SequenceAction 
+        id="complete"
+        from="webcheckout" 
+        to="webcheckout"
+        positionX="630"
+        positionY="310" 
+        sourcePositionY="238"
+        targetPositionY="388"
+        message={t.complete}
+    />
+    <SequenceAction 
+        id="return2"
+        from="webcheckout" 
+        to="server" 
+        positionX="320"
+        positionY="400"
+        message={t.returnUrl}
+    />
+    <Line id="lineQuery" label={t.query} positionX="-100" positionY="470" width="800px" />
+    <SequenceAction 
+        id="checkSession"  
+        from="server" 
+        to="webcheckout" 
+        message={t.querySession}
+        positionX="320"
+        positionY="520" 
+    />
+    <SequenceAction 
+        id="statusSession"  
+        from="webcheckout" 
+        to="server" 
+        message={t.queryStatus}
+        positionX="270"
+        positionY="570" 
+    />
+    <Line id="lineConfirm" label={t.confirm} positionX="-150" positionY="630" width="800px" />
+    <SequenceAction 
+        id="confirm"  
+        from="server" 
+        to="webcheckout" 
+        message={t.confirmAction}
+        positionX="300" 
+        positionY="670" 
+    />
+    <SequenceAction 
+        id="finalStatus"  
+        from="webcheckout" 
+        to="server" 
+        message={t.finalStatus}
+        positionX="330"
+        positionY="730" 
+    />
+    <SequenceAction 
+        id="detail"  
+        from="server" 
+        to="site" 
+        message={t.detail}
+        positionX="35" 
+        positionY="730" 
+    />
+    </SequenceDiagram>
+  )
+}

--- a/src/components/react-flow/SessionStates.jsx
+++ b/src/components/react-flow/SessionStates.jsx
@@ -6,12 +6,15 @@ const initialNodes = [
 
     { id: 'ACTION_T_APPROVED', type: 'action', position: { x: 200, y: -95 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Approved Transaction', rounded: true } },
     { id: 'ACTION_T_REJECTED', type: 'action', position: { x: 200, y: -25 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Rejected Transaction', rounded: true } },
-    { id: 'ACTION_EXPIRATION', type: 'action', position: { x: 200, y: 45 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Expiration time ends', rounded: true } },
-    { id: 'ACTION_USER_CANCEL', type: 'action', position: { x: 200, y: 115 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'User canceled', rounded: true } },
+    
+    { id: 'ACTION_T_CAPTURED', type: 'action', position: { x: 200, y: 45 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Captured Transaction [1]', rounded: true } },
+
+    { id: 'ACTION_EXPIRATION', type: 'action', position: { x: 200, y: 115 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'Expiration time ends', rounded: true } },
+    { id: 'ACTION_USER_CANCEL', type: 'action', position: { x: 200, y: 185 }, sourcePosition: 'right', targetPosition: 'left', data: { label: 'User canceled', rounded: true } },
 
     { id: 'STATE_APPROVED', type:'tag', position: { x: 450, y: -110 }, data: { label: "Session", tagLabel: 'APPROVED', tagColor: 'primary', sourceHandle: false } },
-    { id: 'STATE_PENDING_2', type: 'tag', position: { x: 450, y: -25 }, data: { label: "Session", tagLabel: 'PENDING', tagColor: 'amber', sourceHandle: false} },
-    { id: 'STATE_REJECTED', type: 'tag', position: { x: 450, y: 60 }, data: { label: "Session", tagLabel: 'REJECTED', tagColor: 'rose', sourceHandle: false} },
+    { id: 'STATE_PENDING_2', type: 'tag', position: { x: 450, y: 0 }, data: { label: "Session", tagLabel: 'PENDING', tagColor: 'amber', sourceHandle: false} },
+    { id: 'STATE_REJECTED', type: 'tag', position: { x: 450, y: 130 }, data: { label: "Session", tagLabel: 'REJECTED', tagColor: 'rose', sourceHandle: false} },
 ];
 
 const initialEdges = [
@@ -26,6 +29,10 @@ const initialEdges = [
 
     { id: 'e__7', source: 'STATE_PENDING', target: 'ACTION_T_REJECTED' },
     { id: 'e__8', source: 'ACTION_T_REJECTED', target: 'STATE_PENDING_2' },
+
+    { id: 'e__9', source: 'STATE_PENDING', target: 'ACTION_T_CAPTURED' },
+    { id: 'e__10', source: 'ACTION_T_CAPTURED', target: 'STATE_PENDING_2' },
+
 ];
 
 

--- a/src/constants/navigations.js
+++ b/src/constants/navigations.js
@@ -631,7 +631,7 @@ export const TAB_NAVIGATION = {
                 href: '/checkout/attempts-limit',
               },
               {
-                title: 'Transacciones con confirmación',
+                title: 'Sesiones con confirmación',
                 href: '/checkout/confirmation-flow',
               }
             ],
@@ -734,6 +734,10 @@ export const TAB_NAVIGATION = {
               {
                 title: 'Process retries',
                 href: '/checkout/attempts-limit',
+              },
+              {
+                title: 'Session with confirmation',
+                href: '/checkout/confirmation-flow',
               },
             ],
           },

--- a/src/constants/navigations.js
+++ b/src/constants/navigations.js
@@ -630,6 +630,10 @@ export const TAB_NAVIGATION = {
                 title: 'Reintentos del proceso',
                 href: '/checkout/attempts-limit',
               },
+              {
+                title: 'Transacciones con confirmación',
+                href: '/checkout/confirmation-flow',
+              }
             ],
           },
         ],

--- a/src/pages/checkout/api/reference/payment.mdx
+++ b/src/pages/checkout/api/reference/payment.mdx
@@ -13,7 +13,7 @@ Se identifica como pago, a una transacción realizada por el usuario dentro de u
 
 <Row>
     <Col>
-        Permite realizar operaciones básicas de preauthorización como `checkout`, `reauthorization`, (No aplica para Puerto Rico) por otro lado también permite revertir un pago aprobado con el código de referencia interna `reverse`.
+        Permite realizar operaciones básicas de preauthorización como `checkout`, `reauthorization`, (No aplica para Puerto Rico) y revertir un pago aprobado con el código de referencia interna `reverse`. Adicionalmente, las transacciones creadas con `requiresConfirmation` pueden ser confirmadas (`confirm`) o canceladas (`cancel`).
 
         <ApiReader
             path="/api/transaction"
@@ -71,6 +71,34 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
         },
         "internalReference": 640,
         "action": "reverse"
+    }"
+```
+```bash {{ title: 'CONFIRM' }}
+curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
+    -H "Content-Type: application/json" \
+    -d "{
+        "auth": {
+            "login": "aabbccdd1234567890aabbccdd123456",
+            "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+            "nonce": "NjE0OWVkODgwYjNhNw==",
+            "seed": "2021-09-21T09:34:48-05:00"
+        },
+        "internalReference": 84,
+        "action": "confirm"
+    }"
+```
+```bash {{ title: 'CANCEL' }}
+curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
+    -H "Content-Type: application/json" \
+    -d "{
+        "auth": {
+            "login": "aabbccdd1234567890aabbccdd123456",
+            "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+            "nonce": "NjE0OWVkODgwYjNhNw==",
+            "seed": "2021-09-21T09:34:48-05:00"
+        },
+        "internalReference": 84,
+        "action": "cancel"
     }"
 ```
         </CodeGroup>
@@ -286,6 +314,94 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
         "receipt": "499435368733",
         "franchise": "PS_VS",
         "refunded": false
+    }
+}
+```
+```json {{ title: 'Confirmar' }}
+{
+    "status": {
+        "status": "APPROVED",
+        "reason": "00",
+        "message": "Aprobada",
+        "date": "2025-01-21T21:20:07-05:00"
+    },
+    "payment": {
+        "status": {
+            "status": "APPROVED",
+            "reason": "00",
+            "message": "Aprobada",
+            "date": "2025-01-21T21:20:07-05:00"
+        },
+        "internalReference": 84,
+        "paymentMethod": "visa",
+        "paymentMethodName": "Visa",
+        "issuerName": "JPMORGAN CHASE BANK, N.A.",
+        "amount": {
+            "from": { "currency": "USD", "total": 100 },
+            "to": { "currency": "USD", "total": 100 },
+            "factor": 1
+        },
+        "authorization": "000000",
+        "reference": "TEST_VISA",
+        "receipt": "426882",
+        "franchise": "CR_VS",
+        "refunded": false
+    }
+}
+```
+```json {{ title: 'Cancelar' }}
+{
+    "status": {
+        "status": "REJECTED",
+        "reason": "?C",
+        "message": "Cancelada por el comercio",
+        "date": "2025-01-21T21:20:07-05:00"
+    },
+    "payment": {
+        "status": {
+            "status": "REJECTED",
+            "reason": "?C",
+            "message": "Cancelada por el comercio",
+            "date": "2025-01-21T21:20:07-05:00"
+        },
+        "internalReference": 84,
+        "paymentMethod": "visa",
+        "paymentMethodName": "Visa",
+        "issuerName": "JPMORGAN CHASE BANK, N.A.",
+        "amount": {
+            "from": { "currency": "USD", "total": 100 },
+            "to": { "currency": "USD", "total": 100 },
+            "factor": 1
+        },
+        "authorization": "000000",
+        "reference": "TEST_VISA",
+        "receipt": "426882",
+        "franchise": "CR_VS",
+        "refunded": false
+    }
+}
+```
+        </CodeGroup>
+
+        <br />
+        <CodeGroup title="Respuestas de error">
+```json {{ title: 'Sesión No Soportada' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "request_not_valid",
+        "message": "La acción [confirm] no está soportada para esta sesión",
+        "date": "2025-01-21T21:20:07-05:00"
+    }
+}
+```
+```json {{ title: 'Estado Inválido' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "request_not_valid",
+        "message": "La acción [confirm] solo está disponible para transacciones en estado pendiente de confirmación",
+        "date": "2025-01-21T21:20:07-05:00"
     }
 }
 ```

--- a/src/pages/checkout/api/reference/payment.mdx
+++ b/src/pages/checkout/api/reference/payment.mdx
@@ -117,7 +117,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     <Col sticky>
         <br />
         <CodeGroup title="Respuesta">
-```json {{ title: 'Default' }}
+```json {{ title: '200: Default' }}
 {
     "reference": "12345",
     "description": "Prueba de pago",
@@ -203,7 +203,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     ]
 }
 ```
-```json {{ title: 'Checkout' }}
+```json {{ title: '200: Checkout' }}
 {
     "status": {
         "status": "APPROVED",
@@ -241,7 +241,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Reauthorization'}}
+```json {{ title: '200: Reauthorization'}}
 {
     "status": {
         "status": "APPROVED",
@@ -279,7 +279,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Reverse' }}
+```json {{ title: '200: Reverse' }}
 {
     "status": {
         "status": "APPROVED",
@@ -317,7 +317,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Confirmar' }}
+```json {{ title: '200: Confirmar - Aprobado' }}
 {
     "status": {
         "status": "APPROVED",
@@ -349,7 +349,49 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Cancelar' }}
+```json {{ title: '200: Confirmar - Fallida' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "BR",
+        "message": "La petición no puede ser procesada",
+        "date": "2025-01-21T21:20:07-05:00"
+    },
+    "payment": {
+        "status": {
+            "status": "FAILED",
+            "reason": "BR",
+            "message": "La petición no puede ser procesada",
+            "date": "2025-01-21T21:20:07-05:00"
+        },
+        "internalReference": 84,
+        "paymentMethod": "visa",
+        "paymentMethodName": "Visa",
+        "issuerName": "JPMORGAN CHASE BANK, N.A.",
+        "amount": {
+            "from": { "currency": "USD", "total": 100 },
+            "to": { "currency": "USD", "total": 100 },
+            "factor": 1
+        },
+        "authorization": "000000",
+        "reference": "TEST_VISA",
+        "receipt": "426882",
+        "franchise": "CR_VS",
+        "refunded": false
+    }
+}
+```
+```json {{ title: '400: Confirmar - Fallida por expiración' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "transaction_request_error",
+        "message": "La transacción ya ha sido expirada",
+        "date": "2025-01-21T21:20:07-05:00"
+    }
+}
+```
+```json {{ title: '200: Cancelar' }}
 {
     "status": {
         "status": "REJECTED",

--- a/src/pages/checkout/api/reference/session.mdx
+++ b/src/pages/checkout/api/reference/session.mdx
@@ -360,7 +360,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session \
   }'
 ```
 
-```bash {{ title: 'Crear sesión con requiere confirmación' }}
+```bash {{ title: 'Crear sesión con confirmación' }}
 curl -X "POST" https://checkout-test.placetopay.com/api/session \
   -H "Content-Type: application/json" \
   -d '{
@@ -909,7 +909,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
   "subscription": null
 }
 ```
-```json {{ title: '200: PENDIENTE_CONFIRMACIÓN'}}
+```json {{ title: '200: PENDIENTE con Transaction pendiente de confirmación'}}
 {
   "requestId": 1,
   "status": {

--- a/src/pages/checkout/api/reference/session.mdx
+++ b/src/pages/checkout/api/reference/session.mdx
@@ -360,6 +360,35 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session \
   }'
 ```
 
+```bash {{ title: 'Crear sesión con requiere confirmación' }}
+curl -X "POST" https://checkout-test.placetopay.com/api/session \
+  -H "Content-Type: application/json" \
+  -d '{
+    "locale": "es_CO",
+    "auth": {
+      "login": "aabbccdd1234567890aabbccdd123456",
+      "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+      "nonce": "NjE0OWVkODgwYjNhNw==",
+      "seed": "2021-09-21T09:34:48-05:00"
+    },
+    "payment": {
+      "reference": "ORD-2026-001",
+      "description": "Pago de prueba",
+      "amount": {
+        "currency": "USD",
+        "total": 500
+      }
+    },
+    "metadata": {
+      "requiresConfirmation": true
+    },
+    "expiration": "2026-12-30T00:00:00-05:00",
+    "returnUrl": "https://comercio.com/retorno",
+    "ipAddress": "127.0.0.1",
+    "userAgent": "Placetopay Sandbox"
+  }'
+```
+
 ```bash {{ title: 'Sesión para crear autopago - Monto Fijo' }}
 curl -X "POST" https://checkout-test.placetopay.com/api/session \
   -H "Content-Type: application/json" \
@@ -877,6 +906,60 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
     "expiration": "2021-12-30T00:00:00-05:00"
   },
   "payment": null,
+  "subscription": null
+}
+```
+```json {{ title: '200: PENDIENTE_CONFIRMACIÓN'}}
+{
+  "requestId": 1,
+  "status": {
+    "status": "PENDING",
+    "reason": "PT",
+    "message": "La petición se encuentra pendiente",
+    "date": "2025-01-21T21:20:07-05:00"
+  },
+  "request": {
+    "locale": "es_CO",
+    "payment": {
+      "reference": "TEST_VISA",
+      "description": "Pago de prueba",
+      "amount": {
+        "currency": "USD",
+        "total": 100
+      }
+    },
+    "metadata": {
+      "requiresConfirmation": true
+    },
+    "returnUrl": "https://comercio.com/retorno",
+    "ipAddress": "127.0.0.1",
+    "userAgent": "Placetopay Sandbox",
+    "expiration": "2026-12-30T00:00:00-05:00"
+  },
+  "payment": [
+    {
+      "status": {
+        "status": "PENDING_CONFIRMATION",
+        "reason": "PT",
+        "message": "Transacción pendiente de confirmación",
+        "date": "2025-01-21T21:20:07-05:00"
+      },
+      "internalReference": 84,
+      "paymentMethod": "visa",
+      "paymentMethodName": "Visa",
+      "issuerName": "JPMORGAN CHASE BANK, N.A.",
+      "amount": {
+        "from": { "currency": "USD", "total": 100 },
+        "to": { "currency": "USD", "total": 100 },
+        "factor": 1
+      },
+      "authorization": "000000",
+      "reference": "TEST_VISA",
+      "receipt": "426882",
+      "franchise": "CR_VS",
+      "refunded": false
+    }
+  ],
   "subscription": null
 }
 ```

--- a/src/pages/checkout/confirmation-flow.mdx
+++ b/src/pages/checkout/confirmation-flow.mdx
@@ -1,0 +1,6 @@
+export const description = 'Conoce cómo funciona el proceso de integración para sesiones que requieren confirmación'
+
+# Flujo de transacciones con confirmación
+
+
+## FAQs

--- a/src/pages/checkout/confirmation-flow.mdx
+++ b/src/pages/checkout/confirmation-flow.mdx
@@ -1,6 +1,95 @@
-export const description = 'Conoce cómo funciona el proceso de integración para sesiones que requieren confirmación'
+import ConfirmationFlowStates from "@/components/react-flow/ConfirmationFlowStates";
+import ConfirmationIntegration from "@/components/react-flow/SequenceDiagram/Diagrams/Checkout/ConfirmationIntegration"
 
-# Flujo de transacciones con confirmación
+export const description =
+  'Aprende cómo funciona el flujo de confirmación de transacciones en Checkout y cómo integrarlo en tu sitio o aplicación.'
+
+# Sesiones con confirmación
+
+En Checkout, es posible habilitar el flujo de sesiones con confirmación. En este tipo de sesiones, el usuario o tarjetahabiente completa el proceso en el navegador ingresando los datos del medio de pago, pero la ejecución de la autorización queda en espera de "confirmación". El comercio debe integrar una nueva acción para indicar que se debe ejecutar el proceso de autorización al medio de pago capturado.
+
+Este tipo de transacciones permite al comercio revisar transacciones antes de la aprobación final. Esto es útil para casos de uso donde el comercio requiere ejecutar validación de reglas de negocio antes de que ejecute la autorización al medio de pago.
+
+## Ciclo de vida
+
+1. Cuando tus usuarios estén listos para completar el proceso de pago, tu aplicación debe crear un `CheckoutSession`.
+2. Redireccionar al usuario a la URL provista, esta URL contiene nuestro Checkout con todas sus funcionalidades listas.
+3. El usuario ingresa los datos requeridos para completar el pago.
+4. El usuario es redireccionado de vuelta al sitio del comercio.
+5. El comercio debe consultar el estado de la sesión para revisar los detalles del proceso.
+6. El comercio debe "confirmar" para que se haga la ejecución de la autorización del pago o "cancelar" para que ya no se pueda completar la transacción en proceso.
+7. Después de la confirmación, una notificación es enviada para que la aplicación conozca el estado del pago.
 
 
-## FAQs
+## Integración {{ id: "confirmation-integration" }}
+
+Este tipo de sesiones sólo se soporta para "Sesiones de pago básico"
+
+En el siguiente diagrama se describe de forma visual y con más detalle el flujo de integración para sesiones con confirmación:
+
+<ConfirmationIntegration />
+
+### Iniciar Checkout
+
+**Crear una sesión con confirmación**  
+Para aceptar un pago a través de Checkout con flujo de confirmación, es necesario crear una sesión de pago (**Checkout Session**) con `metadata.requiresConfirmation: true` utilizando el método [API - Crear sesión (CreateRequest)](/checkout/api/reference/session#crear-una-sesion). Al llamar a este servicio, se obtendrá la URL de proceso (`processUrl`) y el identificador de solicitud (`requestId`). Puedes ver más en el apartado [Crear Sesión](/checkout/create-session).
+
+El sitio del comercio debe tener habilitada la configuración `allowConfirmationFlow` — contacta al soporte de Placetopay para activarla.
+
+**Registro del Pago en Proceso**  
+En tu sistema, crear un registro que relacione el pago en proceso con el `requestId` proporcionado.  
+El estado inicial de todos los pagos es pendiente (`PENDING`).
+
+**Redirección del Usuario**  
+El usuario debe ser redireccionado a la URL de proceso (`processUrl`) proporcionada por Placetopay Checkout.
+
+**Proceso de Pago**  
+En la interfaz de Checkout, el usuario completará el proceso de pago ingresando los datos del medio de pago. Checkout se encargará de recopilar todos los datos necesarios.
+
+**Redirección de vuelta al sitio del comercio**  
+Una vez que el proceso de pago esté completo, el usuario puede ser redirigido de vuelta a la URL de retorno (`returnUrl`) especificada en la solicitud inicial (`CreateRequest`).
+
+En este punto es probable que el proceso de pago haya finalizado. Para conocer el estado del pago debes consultar el estado de la sesión.
+
+### Consultar la sesión
+
+**Consulta del estado de la sesión**  
+Al llegar al sitio del comercio, se debe consultar el estado de la sesión.  
+Esto se puede lograr utilizando el método [API - Consultar sesión (getRequestInformation)](/checkout/api/reference/session#query-a-session).
+
+En este punto la sesión tiene un estado `PENDING`, con una transacción adjunta con estado `PENDING_CONFIRMATION`. Esto indica que ya es posible realizar la acción de confirmación o cancelación.
+
+**Revisión y Reglas de Negocio**  
+Revisa los detalles de la transacción y, según tus reglas de negocio, decide si confirmar o cancelar.
+
+### Confirmar o Cancelar
+
+Según la revisión de la transacción, el comercio debe ejecutar una de las siguientes acciones mediante el endpoint de [Acciones de Transacción](/checkout/api/reference/payment#acciones-de-transaccion):
+
+- **Confirmar (`confirm`)**: El comercio autoriza el procesamiento de la transacción.
+  - En este punto se ejecuta la autorización al medio de pago y se hace el cobro correspondiente. 
+  - Esta acción puede fallar pues depende de la red procesadora del medio de pago. 
+  - Esta acción se puede realizar en una ventana de tiempo desde la captura del medio de pago. Después de esa ventana de tiempo, la sesión queda en estado `REJECTED` y la transacción queda en estado `REJECTED`.
+- **Cancelar (`cancel`)**: La transacción es cancelada por el comercio.
+  - Si el comercio decide cancelar, no se va a ejecutar la autorización y no se harán cobros al medio de pago.
+  - Al cancelar, la sesión queda en estado `CANCELED` y la transacción queda en estado `REJECTED`.
+  - Para reintentar, se debe crear una nueva sesión.
+
+## Estados de sesión {{ id: "confirmation-session-states" }}
+
+A continuación, se muestran los estados posibles en una sesión con flujo de confirmación y cómo se relacionan entre sí:
+
+<ConfirmationFlowStates />
+
+## Mejores prácticas {{ id: "confirmation-best-practices" }}
+
+### Usar skipResult
+
+Debido a que una sesión con confirmación siempre queda en estado `PENDING` hasta que el comercio la confirme o cancele, es recomendable utilizar la opción [Omitir resultado (skipResult)](/checkout/skip-result) para que el usuario sea redireccionado de vuelta al sitio del comercio inmediatamente después de completar el pago, sin esperar en la vista de resultado de Checkout.
+
+## Consideraciones de Seguridad {{ id: 'confirmation-security-considerations' }}
+
+**Los endpoints de Webcheckout NO deben consumirse directamente desde el navegador** (ej: JavaScript/AJAX). Esto expone credenciales API y datos sensibles a riesgos de:
+- **Interceptación de claves** por scripts maliciosos
+- **Exposición de datos** en consola del cliente
+- **Vulnerabilidad a ataques XSS**

--- a/src/pages/checkout/how-checkout-works.mdx
+++ b/src/pages/checkout/how-checkout-works.mdx
@@ -1,5 +1,6 @@
 import SessionStates from "@/components/react-flow/SessionStates";
 import PartialSessionStates from "@/components/react-flow/PartialSessionStates";
+import ConfirmationFlowStates from "@/components/react-flow/ConfirmationFlowStates";
 import IntegrationSequence from "@/components/react-flow/SequenceDiagram/Diagrams/Checkout/es/IntegrationSequence"
 
 export const description =
@@ -69,6 +70,43 @@ Esto se puede lograr utilizando el método [API - Consultar sesión (getRequestI
 **Actualización y Reglas de Negocio**  
 Según el estado final del pago obtenido, debes ejecutar las reglas de negocio correspondientes y actualizar la información relacionada con el pago en tu sistema.
 
+### Flujo de Confirmación de Transacciones
+
+El flujo de confirmación te permite revisar transacciones antes de la aprobación final. Esto es útil para prevención de fraude, revisión manual o validación de reglas de negocio.
+
+**Cómo Habilitarlo**
+
+Agrega `metadata.requiresConfirmation: true` al crear una sesión. El sitio del comercio debe tener habilitada la configuración `allowConfirmationFlow` — contacta al soporte de Placetopay para activarla.
+
+**Flujos Soportados**
+
+- Pagos simples (`payment`)
+- Suscripciones (`subscription`)
+- Pagos con dispersión (`payment.dispersion`)
+- Flujo check-in (`type: checkin`)
+
+**Flujos No Soportados**
+
+- Pagos con `allowPartial: true`
+- Pagos con `subscribe: true`
+- Pagos recurrentes (`payment.recurring`)
+- Sesiones de autopago (`type: autopay`)
+
+**Flujo del Proceso**
+
+1. El usuario completa el pago en Checkout
+2. La transacción se crea en estado `PENDING_CONFIRMATION` mientras la sesión permanece `PENDING`
+3. El comercio recibe una notificación y consulta la sesión para revisar los detalles de la transacción
+4. El comercio llama a `confirm` o `cancel` mediante el endpoint de [Acciones de Transacción](/checkout/api/reference/payment#acciones-de-transaccion)
+5. Se envía una notificación final con el estado definitivo de la transacción
+
+**Notas de Comportamiento**
+
+- `session.skipResult` se fuerza a `true` — el usuario regresa al comercio inmediatamente después del pago
+- El `redirectUrl` en la respuesta del proceso es `null`
+- La sesión permanece `PENDING` mientras la transacción espera confirmación
+- El campo `amount` **no es requerido** para las acciones `confirm` o `cancel`
+
 ## Estados de sesión {{ id: "checkout-session-states" }}
 
 Las sesiones pueden atravesar diferentes estados, cada uno con su propio significado y secuencia de cambios. A continuación, presentamos los estados posibles y cómo se relacionan entre sí:
@@ -76,7 +114,7 @@ Las sesiones pueden atravesar diferentes estados, cada uno con su propio signifi
 **`PENDING` Pendiente:**
 Se presenta en tres situaciones: en primer lugar, es el estado inicial de la sesión e indica que el proceso está en espera de acciones por parte del usuario;
 en segundo lugar, cuando hay transacciones rechazadas, permitiendo al usuario la oportunidad de realizar nuevos intentos;
-y, por último, cuando existe una transacción pendiente de validación lo que indica que la sesión se encuentra en un estado de espera hasta que se confirme y valide la transacción.
+y, por último, cuando existe una transacción en estado `PENDING_CONFIRMATION`, indicando que la sesión se encuentra en espera hasta que el comercio confirme o cancele la transacción.
 En resumen, es un estado de espera e indica que el proceso no ha finalizado.
 
 **`APPROVED` Aprobado:**
@@ -98,6 +136,9 @@ En este momento el proceso ya ha finalizado y no se puede completar. _Este es un
 
 ### Estados en sesiones de pago parcial
 <PartialSessionStates></PartialSessionStates>
+
+### Estados en sesiones de pago pendiente de confirmación
+<ConfirmationFlowStates />
 
 ## Finalización de la sesión {{ id: "session-finalization" }}
 

--- a/src/pages/checkout/how-checkout-works.mdx
+++ b/src/pages/checkout/how-checkout-works.mdx
@@ -26,13 +26,6 @@ En el siguiente diagrama se describe de forma visual y con más detalle el ciclo
 
 <IntegrationSequence />
 
-## Consideraciones de Seguridad {{ id: 'checkout-security-considerations' }}
-
-**Los endpoints de Webcheckout NO deben consumirse directamente desde el navegador** (ej: JavaScript/AJAX). Esto expone credenciales API y datos sensibles a riesgos de:
-- **Interceptación de claves** por scripts maliciosos
-- **Exposición de datos** en consola del cliente
-- **Vulnerabilidad a ataques XSS**
-
 ### Iniciar Checkout
 
 **Crear una sesión de pago**  
@@ -112,10 +105,12 @@ Agrega `metadata.requiresConfirmation: true` al crear una sesión. El sitio del 
 Las sesiones pueden atravesar diferentes estados, cada uno con su propio significado y secuencia de cambios. A continuación, presentamos los estados posibles y cómo se relacionan entre sí:
 
 **`PENDING` Pendiente:**
-Se presenta en tres situaciones: en primer lugar, es el estado inicial de la sesión e indica que el proceso está en espera de acciones por parte del usuario;
-en segundo lugar, cuando hay transacciones rechazadas, permitiendo al usuario la oportunidad de realizar nuevos intentos;
-y, por último, cuando existe una transacción en estado `PENDING_CONFIRMATION`, indicando que la sesión se encuentra en espera hasta que el comercio confirme o cancele la transacción.
-En resumen, es un estado de espera e indica que el proceso no ha finalizado.
+Es un estado de espera e indica que el proceso no ha finalizado. Hay acciones pendientes por parte del usuario, el comercio o la pasarela de pagos. Se presenta en situaciones como: 
+
+- Es el estado inicial de la sesión e indica que el proceso está en espera de acciones por parte del usuario.
+- Se presenta cuando hay transacciones rechazadas, y el usuario aún tiene la oportunidad de realizar nuevos intentos.
+- Se presenta cuando existe una transacción pendiente de validación manual. Puede ser por seguridad o por un proceso administrativo, lo que indica que la sesión se encuentra en un estado de espera hasta que se confirme y valide la transacción.
+- Se presenta cuando existe una transacción en espera de confirmación. El comercio aún debe ejecutar el proceso de confirmación o cancelación para continuar con la autorización.
 
 **`APPROVED` Aprobado:**
 Este estado se presenta cuando las transacciones se han aprobado y el proceso se ha completado con éxito. _Este es un estado final de proceso._
@@ -133,6 +128,8 @@ En este momento el proceso ya ha finalizado y no se puede completar. _Este es un
 
 ### Estados en sesiones
 <SessionStates></SessionStates>
+
+- [1] El concepto de "Captured Transaction / Transacción Capturada" hace referencia al "Flujo de transacciónes con confirmación", para integrarte con este flujo, dirigete a [Flujo de transacciónes con confirmación](#confirmation-flow).
 
 ### Estados en sesiones de pago parcial
 <PartialSessionStates></PartialSessionStates>
@@ -170,6 +167,14 @@ Para realizar seguimiento o modificaciones de estas entidades, el comercio integ
 - [API de Pagos](/checkout/api/reference/payment) para transacciones
 - [API de Tokens](/checkout/api/reference/token) para suscripciones
 - [API de Autopay](/autopay/api) para autopagos
+
+## Consideraciones de Seguridad {{ id: 'checkout-security-considerations' }}
+
+**Los endpoints de Webcheckout NO deben consumirse directamente desde el navegador** (ej: JavaScript/AJAX). Esto expone credenciales API y datos sensibles a riesgos de:
+- **Interceptación de claves** por scripts maliciosos
+- **Exposición de datos** en consola del cliente
+- **Vulnerabilidad a ataques XSS**
+
 
 ## ¿Qué sigue? {{ id: "checkout-next" }}
 

--- a/src/pages/checkout/how-checkout-works.mdx
+++ b/src/pages/checkout/how-checkout-works.mdx
@@ -1,6 +1,5 @@
 import SessionStates from "@/components/react-flow/SessionStates";
 import PartialSessionStates from "@/components/react-flow/PartialSessionStates";
-import ConfirmationFlowStates from "@/components/react-flow/ConfirmationFlowStates";
 import IntegrationSequence from "@/components/react-flow/SequenceDiagram/Diagrams/Checkout/es/IntegrationSequence"
 
 export const description =
@@ -63,43 +62,6 @@ Esto se puede lograr utilizando el método [API - Consultar sesión (getRequestI
 **Actualización y Reglas de Negocio**  
 Según el estado final del pago obtenido, debes ejecutar las reglas de negocio correspondientes y actualizar la información relacionada con el pago en tu sistema.
 
-### Flujo de Confirmación de Transacciones
-
-El flujo de confirmación te permite revisar transacciones antes de la aprobación final. Esto es útil para prevención de fraude, revisión manual o validación de reglas de negocio.
-
-**Cómo Habilitarlo**
-
-Agrega `metadata.requiresConfirmation: true` al crear una sesión. El sitio del comercio debe tener habilitada la configuración `allowConfirmationFlow` — contacta al soporte de Placetopay para activarla.
-
-**Flujos Soportados**
-
-- Pagos simples (`payment`)
-- Suscripciones (`subscription`)
-- Pagos con dispersión (`payment.dispersion`)
-- Flujo check-in (`type: checkin`)
-
-**Flujos No Soportados**
-
-- Pagos con `allowPartial: true`
-- Pagos con `subscribe: true`
-- Pagos recurrentes (`payment.recurring`)
-- Sesiones de autopago (`type: autopay`)
-
-**Flujo del Proceso**
-
-1. El usuario completa el pago en Checkout
-2. La transacción se crea en estado `PENDING_CONFIRMATION` mientras la sesión permanece `PENDING`
-3. El comercio recibe una notificación y consulta la sesión para revisar los detalles de la transacción
-4. El comercio llama a `confirm` o `cancel` mediante el endpoint de [Acciones de Transacción](/checkout/api/reference/payment#acciones-de-transaccion)
-5. Se envía una notificación final con el estado definitivo de la transacción
-
-**Notas de Comportamiento**
-
-- `session.skipResult` se fuerza a `true` — el usuario regresa al comercio inmediatamente después del pago
-- El `redirectUrl` en la respuesta del proceso es `null`
-- La sesión permanece `PENDING` mientras la transacción espera confirmación
-- El campo `amount` **no es requerido** para las acciones `confirm` o `cancel`
-
 ## Estados de sesión {{ id: "checkout-session-states" }}
 
 Las sesiones pueden atravesar diferentes estados, cada uno con su propio significado y secuencia de cambios. A continuación, presentamos los estados posibles y cómo se relacionan entre sí:
@@ -129,13 +91,10 @@ En este momento el proceso ya ha finalizado y no se puede completar. _Este es un
 ### Estados en sesiones
 <SessionStates></SessionStates>
 
-- [1] El concepto de "Captured Transaction / Transacción Capturada" hace referencia al "Flujo de transacciónes con confirmación", para integrarte con este flujo, dirigete a [Flujo de transacciónes con confirmación](#confirmation-flow).
+- [1] El concepto de "Captured Transaction / Transacción Capturada" hace referencia al "Flujo de transacciones con confirmación", para integrarte con este flujo, dirigete a [Transacciones con confirmación](/checkout/confirmation-flow).
 
 ### Estados en sesiones de pago parcial
 <PartialSessionStates></PartialSessionStates>
-
-### Estados en sesiones de pago pendiente de confirmación
-<ConfirmationFlowStates />
 
 ## Finalización de la sesión {{ id: "session-finalization" }}
 
@@ -181,4 +140,5 @@ Para realizar seguimiento o modificaciones de estas entidades, el comercio integ
 Listo, ahora que entiendes el ciclo de vida puedes continuar con:
 
 - [Crear Sesión](/checkout/create-session)
+- [Transacciones con confirmación](/checkout/confirmation-flow)
 - [Plugins y librerías](/checkout/plugins)

--- a/src/pages/checkout/metadata.mdx
+++ b/src/pages/checkout/metadata.mdx
@@ -19,6 +19,7 @@ Actualmente, la estructura de clave-valor puede incluirse en las solicitudes de 
 | `EBTDeliveryIndicator` | `DIRECT_DELIVERY`, `CUSTOMER_PICKUP`, `COMMERCIAL_SHIPPING`, `OTHER`, `NOT_AVAILABLE` | Indica el método de entrega relacionado con el beneficio EBT. |
 | `openingDate`          | `string` con formato de fecha (YYYY-MM-DD) | Fecha de creación de cuenta. Requerida para PSE en comercios con categoría “Servicios Financieros”. |
 | `beneficiaryId`        | `string`           | ID del beneficiario asociado a la cuenta receptora en una transacción PSE. Requerido para comercios con categoría “Servicios Financieros”. |
+| `requiresConfirmation` | `true`, `false`    | Cuando se establece en `true`, la transacción requerirá confirmación por parte del comercio antes de la autorización final. Requiere tener habilitada la configuración `allowConfirmationFlow` en el comercio. |
 
 <Note>
 Si se envía un valor distinto a los permitidos para cualquiera de las claves, la API responderá con un error. 
@@ -38,6 +39,7 @@ La propiedad `metadata` se puede incluir dentro de la estructura principal de la
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",
+      "requiresConfirmation": true,
    },
    ...
 }
@@ -53,6 +55,7 @@ La propiedad `metadata` se puede incluir dentro de la estructura principal de la
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",
+      "requiresConfirmation": true,
    },
    ...
 }

--- a/src/pages/en/checkout/api/reference/payment.mdx
+++ b/src/pages/en/checkout/api/reference/payment.mdx
@@ -13,7 +13,7 @@ A transaction made by the user within a payment session is identified as payment
 
 <Row>
     <Col>
-        It allows you to perform basic preauthorization operations such as `checkout`, `reauthorization`, (Does not apply to Puerto Rico) on the other hand it also allows you to reverse an approved payment with the internal reference code `reverse`.
+        It allows you to perform basic preauthorization operations such as `checkout`, `reauthorization`, (Does not apply to Puerto Rico) and to reverse an approved payment with the internal reference code `reverse`. Additionally, transactions created with `requiresConfirmation` can be confirmed (`confirm`) or cancelled (`cancel`).
 
         <ApiReader
             path="/api/transaction"
@@ -71,6 +71,34 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
         },
         "internalReference": 640,
         "action": "reverse"
+    }"
+```
+```bash {{ title: 'Confirm' }}
+curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
+    -H "Content-Type: application/json" \
+    -d "{
+        "auth": {
+            "login": "aabbccdd1234567890aabbccdd123456",
+            "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+            "nonce": "NjE0OWVkODgwYjNhNw==",
+            "seed": "2021-09-21T09:34:48-05:00"
+        },
+        "internalReference": 84,
+        "action": "confirm"
+    }"
+```
+```bash {{ title: 'Cancel' }}
+curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
+    -H "Content-Type: application/json" \
+    -d "{
+        "auth": {
+            "login": "aabbccdd1234567890aabbccdd123456",
+            "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+            "nonce": "NjE0OWVkODgwYjNhNw==",
+            "seed": "2021-09-21T09:34:48-05:00"
+        },
+        "internalReference": 84,
+        "action": "cancel"
     }"
 ```
         </CodeGroup>
@@ -256,14 +284,14 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     "status": {
         "status": "APPROVED",
         "reason": "00",
-        "message": "Aprobada",
+        "message": "Approved",
         "date": "2021-11-30T09:37:46-05:00"
     },
     "payment": {
         "status": {
         "status": "APPROVED",
         "reason": "00",
-        "message": "Aprobada",
+        "message": "Approved",
         "date": "2021-11-30T09:37:46-05:00"
         },
         "internalReference": 644,
@@ -286,6 +314,94 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
         "receipt": "499435368733",
         "franchise": "PS_VS",
         "refunded": false
+    }
+}
+```
+```json {{ title: 'Confirm' }}
+{
+    "status": {
+        "status": "APPROVED",
+        "reason": "00",
+        "message": "Approved",
+        "date": "2025-01-21T21:20:07-05:00"
+    },
+    "payment": {
+        "status": {
+            "status": "APPROVED",
+            "reason": "00",
+            "message": "Approved",
+            "date": "2025-01-21T21:20:07-05:00"
+        },
+        "internalReference": 84,
+        "paymentMethod": "visa",
+        "paymentMethodName": "Visa",
+        "issuerName": "JPMORGAN CHASE BANK, N.A.",
+        "amount": {
+            "from": { "currency": "USD", "total": 100 },
+            "to": { "currency": "USD", "total": 100 },
+            "factor": 1
+        },
+        "authorization": "000000",
+        "reference": "TEST_VISA",
+        "receipt": "426882",
+        "franchise": "CR_VS",
+        "refunded": false
+    }
+}
+```
+```json {{ title: 'Cancel' }}
+{
+    "status": {
+        "status": "REJECTED",
+        "reason": "?C",
+        "message": "Cancelled by merchant",
+        "date": "2025-01-21T21:20:07-05:00"
+    },
+    "payment": {
+        "status": {
+            "status": "REJECTED",
+            "reason": "?C",
+            "message": "Cancelled by merchant",
+            "date": "2025-01-21T21:20:07-05:00"
+        },
+        "internalReference": 84,
+        "paymentMethod": "visa",
+        "paymentMethodName": "Visa",
+        "issuerName": "JPMORGAN CHASE BANK, N.A.",
+        "amount": {
+            "from": { "currency": "USD", "total": 100 },
+            "to": { "currency": "USD", "total": 100 },
+            "factor": 1
+        },
+        "authorization": "000000",
+        "reference": "TEST_VISA",
+        "receipt": "426882",
+        "franchise": "CR_VS",
+        "refunded": false
+    }
+}
+```
+        </CodeGroup>
+
+        <br />
+        <CodeGroup title="Error responses">
+```json {{ title: 'Session Not Supported' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "request_not_valid",
+        "message": "The action [confirm] is not supported for this session",
+        "date": "2025-01-21T21:20:07-05:00"
+    }
+}
+```
+```json {{ title: 'Invalid State' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "request_not_valid",
+        "message": "The action [confirm] is only available for transactions in pending confirmation state",
+        "date": "2025-01-21T21:20:07-05:00"
     }
 }
 ```

--- a/src/pages/en/checkout/api/reference/payment.mdx
+++ b/src/pages/en/checkout/api/reference/payment.mdx
@@ -117,7 +117,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     <Col sticky>
         <br />
         <CodeGroup title="Response">
-```json {{ title: 'Default' }}
+```json {{ title: '200: Default' }}
 {
     "reference": "12345",
     "description": "Prueba de pago",
@@ -203,7 +203,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     ]
 }
 ```
-```json {{ title: 'Checkout' }}
+```json {{ title: '200: Checkout' }}
 {
     "status": {
         "status": "APPROVED",
@@ -241,7 +241,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Reauthorization'}}
+```json {{ title: '200: Reauthorization'}}
 {
     "status": {
         "status": "APPROVED",
@@ -279,7 +279,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Reverse' }}
+```json {{ title: '200: Reverse' }}
 {
     "status": {
         "status": "APPROVED",
@@ -317,7 +317,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Confirm' }}
+```json {{ title: '200: Confirm - Approved' }}
 {
     "status": {
         "status": "APPROVED",
@@ -349,7 +349,49 @@ curl -X "POST" https://checkout-test.placetopay.com/api/transaction \
     }
 }
 ```
-```json {{ title: 'Cancel' }}
+```json {{ title: '200: Confirm - Failed' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "BR",
+        "message": "The request could not be processed",
+        "date": "2025-01-21T21:20:07-05:00"
+    },
+    "payment": {
+        "status": {
+            "status": "FAILED",
+            "reason": "BR",
+            "message": "The request could not be processed",
+            "date": "2025-01-21T21:20:07-05:00"
+        },
+        "internalReference": 84,
+        "paymentMethod": "visa",
+        "paymentMethodName": "Visa",
+        "issuerName": "JPMORGAN CHASE BANK, N.A.",
+        "amount": {
+            "from": { "currency": "USD", "total": 100 },
+            "to": { "currency": "USD", "total": 100 },
+            "factor": 1
+        },
+        "authorization": "000000",
+        "reference": "TEST_VISA",
+        "receipt": "426882",
+        "franchise": "CR_VS",
+        "refunded": false
+    }
+}
+```
+```json {{ title: '400: Confirm - Failed due to expiration' }}
+{
+    "status": {
+        "status": "FAILED",
+        "reason": "transaction_request_error",
+        "message": "The transaction has already expired",
+        "date": "2025-01-21T21:20:07-05:00"
+    }
+}
+```
+```json {{ title: '200: Cancel' }}
 {
     "status": {
         "status": "REJECTED",

--- a/src/pages/en/checkout/api/reference/session.mdx
+++ b/src/pages/en/checkout/api/reference/session.mdx
@@ -360,6 +360,35 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session \
   }'
 ```
 
+```bash {{ title: 'Create session with requires confirmation' }}
+curl -X "POST" https://checkout-test.placetopay.com/api/session \
+  -H "Content-Type: application/json" \
+  -d '{
+      "locale": "en_US",
+      "auth": {
+        "login":"aabbccdd1234567890aabbccdd123456",
+        "tranKey":"ABC123example456trankey+789abc012def3456ABC=",
+        "nonce":"NjE0OWVkODgwYjNhNw==",
+        "seed":"2021-09-21T09:34:48-05:00"
+      },
+      "payment": {
+        "reference": "ORD-2026-001",
+        "description": "Test payment",
+        "amount": {
+          "currency": "USD",
+          "total": 500
+        }
+      },
+      "metadata": {
+        "requiresConfirmation": true
+      },
+      "expiration": "2026-12-30T00:00:00-05:00",
+      "returnUrl": "https://merchant.com/return",
+      "ipAddress": "127.0.0.1",
+      "userAgent": "Placetopay Sandbox"
+    }'
+```
+
 ```bash {{ title: 'Autopay session - Fixed Amount' }}
 curl -X "POST" https://checkout-test.placetopay.com/api/session \
   -H "Content-Type: application/json" \
@@ -878,6 +907,60 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
     "expiration": "2021-12-30T00:00:00-05:00"
   },
   "payment": null,
+  "subscription": null
+}
+```
+```json {{ title: '200: PENDING_CONFIRMATION'}}
+{
+  "requestId": 1,
+  "status": {
+    "status": "PENDING",
+    "reason": "PT",
+    "message": "The request is pending",
+    "date": "2025-01-21T21:20:07-05:00"
+  },
+  "request": {
+    "locale": "en_US",
+    "payment": {
+      "reference": "TEST_VISA",
+      "description": "Test payment",
+      "amount": {
+        "currency": "USD",
+        "total": 100
+      }
+    },
+    "metadata": {
+      "requiresConfirmation": true
+    },
+    "returnUrl": "https://merchant.com/return",
+    "ipAddress": "127.0.0.1",
+    "userAgent": "Placetopay Sandbox",
+    "expiration": "2026-12-30T00:00:00-05:00"
+  },
+  "payment": [
+    {
+      "status": {
+        "status": "PENDING_CONFIRMATION",
+        "reason": "PT",
+        "message": "Pending confirmation transaction",
+        "date": "2025-01-21T21:20:07-05:00"
+      },
+      "internalReference": 84,
+      "paymentMethod": "visa",
+      "paymentMethodName": "Visa",
+      "issuerName": "JPMORGAN CHASE BANK, N.A.",
+      "amount": {
+        "from": { "currency": "USD", "total": 100 },
+        "to": { "currency": "USD", "total": 100 },
+        "factor": 1
+      },
+      "authorization": "000000",
+      "reference": "TEST_VISA",
+      "receipt": "426882",
+      "franchise": "CR_VS",
+      "refunded": false
+    }
+  ],
   "subscription": null
 }
 ```

--- a/src/pages/en/checkout/api/reference/session.mdx
+++ b/src/pages/en/checkout/api/reference/session.mdx
@@ -360,7 +360,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session \
   }'
 ```
 
-```bash {{ title: 'Create session with requires confirmation' }}
+```bash {{ title: 'Create session with confirmation' }}
 curl -X "POST" https://checkout-test.placetopay.com/api/session \
   -H "Content-Type: application/json" \
   -d '{
@@ -910,7 +910,7 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
   "subscription": null
 }
 ```
-```json {{ title: '200: PENDING_CONFIRMATION'}}
+```json {{ title: '200: PENDING with Captures Transaction'}}
 {
   "requestId": 1,
   "status": {

--- a/src/pages/en/checkout/confirmation-flow.mdx
+++ b/src/pages/en/checkout/confirmation-flow.mdx
@@ -1,0 +1,95 @@
+import ConfirmationFlowStates from "@/components/react-flow/ConfirmationFlowStates";
+import ConfirmationIntegration from "@/components/react-flow/SequenceDiagram/Diagrams/Checkout/ConfirmationIntegration"
+
+export const description =
+  'Learn how the transaction confirmation flow works in Checkout and how to integrate it into your site or application.'
+
+# Transaction Confirmation Flow
+
+In Checkout, you can enable the session confirmation flow. In this type of session, the user or cardholder completes the process in the browser by entering the payment method details, but the authorization execution remains pending "confirmation". The merchant must integrate a new action to indicate that the authorization process should be executed against the captured payment method.
+
+This type of transaction allows the merchant to review transactions before final approval. This is useful for use cases where the merchant needs to run business rule validations before the payment method authorization is executed.
+
+## Lifecycle
+
+1. When your users are ready to complete the payment process, your application must create a `CheckoutSession`.
+2. Redirect the user to the provided URL; this URL contains our Checkout with all its features ready.
+3. The user enters the data required to complete the payment.
+4. The user is redirected back to the merchant's site.
+5. The merchant must query the session status to review the process details.
+6. The merchant must "confirm" for the payment authorization to be executed or "cancel" so the in-process transaction cannot be completed.
+7. After confirmation, a notification is sent so the application knows the payment status.
+
+
+## Integration {{ id: "confirmation-integration" }}
+
+This type of session is only supported for "Basic payment sessions"
+
+The following diagram visually describes in more detail the integration flow for sessions with confirmation:
+
+<ConfirmationIntegration />
+
+### Start Checkout
+
+**Create a session with confirmation**  
+To accept a payment through Checkout with confirmation flow, you must create a payment session (**Checkout Session**) with `metadata.requiresConfirmation: true` using the [API - Create session (CreateRequest)](/en/checkout/api/reference/session#crear-una-sesion) method. When calling this service, you will obtain the process URL (`processUrl`) and the request identifier (`requestId`). See more in the [Create Session](/en/checkout/create-session) section.
+
+The merchant's site must have the `allowConfirmationFlow` setting enabled — contact Placetopay support to activate it.
+
+**Register the Payment in Process**  
+In your system, create a record that links the payment in process with the provided `requestId`.  
+The initial status of all payments is pending (`PENDING`).
+
+**User Redirection**  
+The user must be redirected to the process URL (`processUrl`) provided by Placetopay Checkout.
+
+**Payment Process**  
+In the Checkout interface, the user will complete the payment process by entering the payment method details. Checkout will handle collecting all the necessary data.
+
+**Redirect back to the merchant's site**  
+Once the payment process is complete, the user can be redirected back to the return URL (`returnUrl`) specified in the initial request (`CreateRequest`).
+
+At this point the payment process is likely finished. To know the payment status you must query the session status.
+
+### Query the session
+
+**Query the session status**  
+Upon arriving at the merchant's site, the session status must be queried.  
+This can be done using the [API - Query session (getRequestInformation)](/en/checkout/api/reference/session#query-a-session) method.
+
+At this point the session has a `PENDING` status, with an attached transaction in `PENDING_CONFIRMATION` status. This indicates that the confirm or cancel action can now be performed.
+
+**Review and Business Rules**  
+Review the transaction details and, based on your business rules, decide whether to confirm or cancel.
+
+### Confirm or Cancel
+
+Based on the transaction review, the merchant must execute one of the following actions via the [Transaction Actions](/en/checkout/api/reference/payment#acciones-de-transaccion) endpoint:
+
+- **Confirm (`confirm`)**: The merchant authorizes the transaction processing.
+  - At this point the authorization to the payment method is executed and the corresponding charge is made. 
+  - This action may fail as it depends on the payment method processing network. 
+  - This action can be performed within a time window from the payment method capture. After that time window, the session enters `REJECTED` status and the transaction enters `REJECTED` status.
+- **Cancel (`cancel`)**: The transaction is cancelled by the merchant.
+  - If the merchant decides to cancel, the authorization will not be executed and no charges will be made to the payment method.
+  - Upon cancellation, the session enters `CANCELED` status and the transaction enters `REJECTED` status.
+  - To retry, a new session must be created.
+
+## Session States {{ id: "confirmation-session-states" }}
+
+Below are the possible states in a confirmation flow session and how they relate to each other:
+
+<ConfirmationFlowStates />
+
+## Best Practices {{ id: "confirmation-best-practices" }}
+
+### Use skipResult
+
+Since a confirmation session always remains in `PENDING` state until the merchant confirms or cancels it, it is recommended to use the [Skip result (skipResult)](/checkout/skip-result) option so the user is redirected back to the merchant's site immediately after completing the payment, without waiting on the Checkout result view.
+
+## Security Considerations {{ id: 'confirmation-security-considerations' }}
+
+**Webcheckout endpoints MUST NOT be accessed directly from the browser** (e.g., JavaScript/AJAX). Doing so exposes API credentials and sensitive data to risks such as:
+- **Key interception** by malicious scripts
+- **Data exposure** in the client console
+- **Vulnerability to XSS attacks**

--- a/src/pages/en/checkout/how-checkout-works.mdx
+++ b/src/pages/en/checkout/how-checkout-works.mdx
@@ -1,5 +1,6 @@
 import SessionStates from "@/components/react-flow/SessionStates";
 import PartialSessionStates from "@/components/react-flow/PartialSessionStates";
+import ConfirmationFlowStates from "@/components/react-flow/ConfirmationFlowStates";
 import IntegrationSequence from "@/components/react-flow/SequenceDiagram/Diagrams/Checkout/en/IntegrationSequence"
 
 export const description =
@@ -69,6 +70,43 @@ This can be achieved using the [API - Query session (getRequestInformation)](/en
 **Update and Business Rules**  
 According to the final status of the payment obtained, you must execute the corresponding business rules and update the information related to the payment in your system.
 
+### Transaction Confirmation Workflow
+
+The confirmation workflow allows you to review transactions before final approval. This is useful for fraud prevention, manual review, or business rule validation.
+
+**How to Enable**
+
+Add `metadata.requiresConfirmation: true` when creating a session. The merchant's site must have the `allowConfirmationFlow` setting enabled — contact Placetopay support to activate it.
+
+**Supported Flows**
+
+- Simple payments (`payment`)
+- Subscriptions (`subscription`)
+- Payments with dispersion (`payment.dispersion`)
+- Check-in flow (`type: checkin`)
+
+**Unsupported Flows**
+
+- Payments with `allowPartial: true`
+- Payments with `subscribe: true`
+- Recurring payments (`payment.recurring`)
+- Autopay sessions (`type: autopay`)
+
+**Process Flow**
+
+1. User completes payment in Checkout
+2. Transaction is created in `PENDING_CONFIRMATION` state while the session stays `PENDING`
+3. Merchant receives notification and queries the session to review transaction details
+4. Merchant calls `confirm` or `cancel` via the [Transaction Actions](/en/checkout/api/reference/payment#transaction-actions) endpoint
+5. Final notification is sent with the transaction's definitive status
+
+**Behavior Notes**
+
+- `session.skipResult` is forced to `true` — the user returns to the merchant immediately after payment
+- The `redirectUrl` in the process response is `null`
+- The session remains `PENDING` while the transaction awaits confirmation
+- The `amount` field is **not required** for `confirm` or `cancel` actions
+
 ## Session States {{ id: "checkout-session-states" }}
 
 Sessions can go through different states, each with its own meaning and sequence of changes. Below we present the possible states and how they relate to each other:
@@ -76,7 +114,7 @@ Sessions can go through different states, each with its own meaning and sequence
 **`PENDING` Pending:**
 It occurs in three situations: firstly, it's the initial state of the session, indicating that the process is waiting for user actions;
 secondly, when there are rejected transactions, allowing the user the opportunity to make new attempts;
-and lastly, when there is a transaction pending validation, indicating that the session is in a waiting state until the transaction is confirmed and validated.
+and lastly, when there is a transaction in `PENDING_CONFIRMATION` state, indicating that the session is in a waiting state until the merchant confirms or cancels the transaction.
 In summary, it is a waiting state and indicates that the process is not yet completed.
 
 **`APPROVED` Approved:**
@@ -98,6 +136,9 @@ At this time the process has already ended and cannot be completed. _This is a f
 
 ### States in partial payment sessions
 <PartialSessionStates></PartialSessionStates>
+
+### States in pending confirmation sessions
+<ConfirmationFlowStates />
 
 ## Session Finalization {{ id: "session-finalization" }}
 

--- a/src/pages/en/checkout/how-checkout-works.mdx
+++ b/src/pages/en/checkout/how-checkout-works.mdx
@@ -1,6 +1,5 @@
 import SessionStates from "@/components/react-flow/SessionStates";
 import PartialSessionStates from "@/components/react-flow/PartialSessionStates";
-import ConfirmationFlowStates from "@/components/react-flow/ConfirmationFlowStates";
 import IntegrationSequence from "@/components/react-flow/SequenceDiagram/Diagrams/Checkout/en/IntegrationSequence"
 
 export const description =
@@ -63,43 +62,6 @@ This can be achieved using the [API - Query session (getRequestInformation)](/en
 **Update and Business Rules**  
 According to the final status of the payment obtained, you must execute the corresponding business rules and update the information related to the payment in your system.
 
-### Transaction Confirmation Workflow
-
-The confirmation workflow allows you to review transactions before final approval. This is useful for fraud prevention, manual review, or business rule validation.
-
-**How to Enable**
-
-Add `metadata.requiresConfirmation: true` when creating a session. The merchant's site must have the `allowConfirmationFlow` setting enabled — contact Placetopay support to activate it.
-
-**Supported Flows**
-
-- Simple payments (`payment`)
-- Subscriptions (`subscription`)
-- Payments with dispersion (`payment.dispersion`)
-- Check-in flow (`type: checkin`)
-
-**Unsupported Flows**
-
-- Payments with `allowPartial: true`
-- Payments with `subscribe: true`
-- Recurring payments (`payment.recurring`)
-- Autopay sessions (`type: autopay`)
-
-**Process Flow**
-
-1. User completes payment in Checkout
-2. Transaction is created in `PENDING_CONFIRMATION` state while the session stays `PENDING`
-3. Merchant receives notification and queries the session to review transaction details
-4. Merchant calls `confirm` or `cancel` via the [Transaction Actions](/en/checkout/api/reference/payment#transaction-actions) endpoint
-5. Final notification is sent with the transaction's definitive status
-
-**Behavior Notes**
-
-- `session.skipResult` is forced to `true` — the user returns to the merchant immediately after payment
-- The `redirectUrl` in the process response is `null`
-- The session remains `PENDING` while the transaction awaits confirmation
-- The `amount` field is **not required** for `confirm` or `cancel` actions
-
 ## Session States {{ id: "checkout-session-states" }}
 
 Sessions can go through different states, each with its own meaning and sequence of changes. Below we present the possible states and how they relate to each other:
@@ -129,13 +91,10 @@ At this time the process has already ended and cannot be completed. _This is a f
 ### States in sessions
 <SessionStates></SessionStates>
 
-- [1] The concept of "Captured Transaction" refers to the "Transaction Confirmation Workflow", to integrate with this flow, go to [Transaction Confirmation Workflow](#confirmation-flow).
+- [1] The concept of "Captured Transaction" refers to the "Transaction Confirmation Workflow", to integrate with this flow, go to [Transaction confirmation](/checkout/confirmation-flow).
 
 ### States in partial payment sessions
 <PartialSessionStates></PartialSessionStates>
-
-### States in pending confirmation sessions
-<ConfirmationFlowStates />
 
 ## Session Finalization {{ id: "session-finalization" }}
 
@@ -181,4 +140,5 @@ To track or modify these entities, the integrating merchant must use the APIs co
 Done, now that you understand the life cycle you can continue with:
 
 - [Create session](/en/checkout/create-session)
+- [Transaction confirmation](/checkout/confirmation-flow)
 - [Plugins and libraries](/en/checkout/plugins)

--- a/src/pages/en/checkout/how-checkout-works.mdx
+++ b/src/pages/en/checkout/how-checkout-works.mdx
@@ -26,13 +26,6 @@ The following diagram describes visually and in more detail the life cycle of a 
 
 <IntegrationSequence />
 
-## Security Considerations {{ id: 'checkout-security-considerations' }}
-
-**Webcheckout endpoints MUST NOT be accessed directly from the browser** (e.g., JavaScript/AJAX). Doing so exposes API credentials and sensitive data to risks such as:
-- **Key interception** by malicious scripts  
-- **Data exposure** in the client console  
-- **Vulnerability to XSS attacks**  
-
 ### Start Checkout
 
 **Create a payment session**  
@@ -112,10 +105,12 @@ Add `metadata.requiresConfirmation: true` when creating a session. The merchant'
 Sessions can go through different states, each with its own meaning and sequence of changes. Below we present the possible states and how they relate to each other:
 
 **`PENDING` Pending:**
-It occurs in three situations: firstly, it's the initial state of the session, indicating that the process is waiting for user actions;
-secondly, when there are rejected transactions, allowing the user the opportunity to make new attempts;
-and lastly, when there is a transaction in `PENDING_CONFIRMATION` state, indicating that the session is in a waiting state until the merchant confirms or cancels the transaction.
-In summary, it is a waiting state and indicates that the process is not yet completed.
+It is a waiting state and indicates that the process has not finished. There are pending actions by the user, the merchant or the payment gateway. It occurs in situations such as:
+
+- It is the initial state of the session and indicates that the process is waiting for actions by the user.
+- It occurs when there are rejected transactions, and the user still has the opportunity to make new attempts.
+- It occurs when there is a transaction pending manual validation. This may be for security reasons or due to an administrative process, indicating that the session is in a waiting state until the transaction is confirmed and validated.
+- It occurs when there is a transaction awaiting confirmation. The merchant must still execute the confirmation or cancellation process to continue with the authorization.
 
 **`APPROVED` Approved:**
 This state occurs when transactions have been approved, and the process has been successfully completed. This is a final process state.
@@ -133,6 +128,8 @@ At this time the process has already ended and cannot be completed. _This is a f
 
 ### States in sessions
 <SessionStates></SessionStates>
+
+- [1] The concept of "Captured Transaction" refers to the "Transaction Confirmation Workflow", to integrate with this flow, go to [Transaction Confirmation Workflow](#confirmation-flow).
 
 ### States in partial payment sessions
 <PartialSessionStates></PartialSessionStates>
@@ -170,6 +167,14 @@ To track or modify these entities, the integrating merchant must use the APIs co
 - [Payments API](/en/checkout/api/reference/payment) for transactions
 - [Tokens API](/en/checkout/api/reference/token) for subscriptions
 - [Autopay API](/autopay/api) for autopays
+
+## Security Considerations {{ id: 'checkout-security-considerations' }}
+
+**Webcheckout endpoints MUST NOT be accessed directly from the browser** (e.g., JavaScript/AJAX). Doing so exposes API credentials and sensitive data to risks such as:
+- **Key interception** by malicious scripts
+- **Data exposure** in the client console
+- **Vulnerability to XSS attacks**
+
 
 ## What's Next? {{ id: "checkout-next" }}
 

--- a/src/pages/en/checkout/metadata.mdx
+++ b/src/pages/en/checkout/metadata.mdx
@@ -19,6 +19,7 @@ Currently, the key-value structure can be included in requests to the following 
 | `EBTDeliveryIndicator` | `DIRECT_DELIVERY`, `CUSTOMER_PICKUP`, `COMMERCIAL_SHIPPING`, `OTHER`, `NOT_AVAILABLE` | Indicates the delivery method related to the EBT benefit. |
 | `openingDate`          | `string` in date format (YYYY-MM-DD) | Account creation date. Required for PSE in merchants with “Financial Services” category. |
 | `beneficiaryId`        | `string`           | Beneficiary ID linked to the receiving account in a PSE transaction. Required for merchants in the “Financial Services” category. |
+| `requiresConfirmation` | `true`, `false`    | When set to `true`, the transaction will require confirmation by the merchant before final authorization. Requires the `allowConfirmationFlow` setting to be enabled for the merchant. |
 
 <Note>
 If a value other than the permitted ones is sent for any of the keys, the API will respond with an error.
@@ -38,6 +39,7 @@ The `metadata` property can be included in the main structure of the request in 
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",
+      "requiresConfirmation": true,
    },
    ...
 }
@@ -53,6 +55,7 @@ The `metadata` property can be included in the main structure of the request in 
       "EBTDeliveryIndicator" : "DIRECT_DELIVERY",
       "openingDate": "2025-02-01",
       "beneficiaryId": "12345",
+      "requiresConfirmation": true,
    },
     ..
 }


### PR DESCRIPTION
 ## Cambios                                                        
- **Documentación flujo**: nueva sección "Flujo de Confirmación" en how-checkout-works.mdx + diagrama ConfirmationFlowStates.
- **payment.mdx**: ejemplos curl y respuestas de confirm, cancel y errores.
- **session.mdx**: ejemplo crear sesión con `requiresConfirmation: true` + respuesta `PENDING_CONFIRMATION`.
--- 
<img width="1434" height="521" alt="image" src="https://github.com/user-attachments/assets/f62741e3-c6bf-4b36-bbf7-e82e0f820181" />
