### PR TITLE
docs: document ATH Movil payment cancellation

### DIFF
--- a/src/assets/apis/gateway/en.yaml
+++ b/src/assets/apis/gateway/en.yaml
@@ -1361,7 +1361,7 @@ paths:
                     
                     `confirm` to confirm a transaction pending confirmation.
                     
-                    `cancel` to cancel a transaction pending confirmation.
+                    `cancel` to cancel a transaction pending confirmation or request remote cancellation of a pending transaction when supported by the provider and service, as with ATH Móvil.
                   enum:
                     - "reverse"
                     - "refund"

--- a/src/assets/apis/gateway/es.yaml
+++ b/src/assets/apis/gateway/es.yaml
@@ -1363,7 +1363,7 @@ paths:
                     
                     `confirm` para procesar una transacción pendiente de confirmación.
                     
-                    `cancel` para cancelar una transacción pendiente de confirmación.
+                    `cancel` para cancelar una transacción pendiente de confirmación o solicitar la cancelación remota de una transacción pendiente cuando el proveedor y el servicio lo permitan, como en ATH Móvil.
                   enum:
                     - "reverse"
                     - "refund"

--- a/src/pages/en/payments/external-redirects/ath-movil.mdx
+++ b/src/pages/en/payments/external-redirects/ath-movil.mdx
@@ -55,7 +55,7 @@ In addition to the phone number, the merchant backend sends the authentication c
 2. The user enters the phone number associated with their ATH Móvil account.
 3. The merchant backend sends the request to `POST /gateway/process`.
 4. ATH Móvil sends a push notification to the user's phone, and the transaction remains `PENDING`.
-5. The user approves or rejects the request in the ATH Móvil application.
+5. While the transaction remains `PENDING`, the user can approve or reject it in the ATH Móvil application; the merchant can also request its cancellation.
 6. The merchant queries the transaction using the `internalReference` and updates its own interface with the final result.
 
 ### Visual component examples {{ id: 'visual-resources' }}
@@ -171,7 +171,8 @@ Use the variant that provides the best contrast with your interface. Files are a
 1. Optionally query ATH Móvil capabilities through `POST /gateway/information`.
 2. Send the charge through `POST /gateway/process`.
 3. Store the `internalReference` from the initial response.
-4. Query `POST /gateway/query` while the status is `PENDING`, and stop when a final result is returned.
+4. To request cancellation of a payment that remains `PENDING`, send `action: "cancel"` to `POST /gateway/transaction`.
+5. Query `POST /gateway/query` while the status is `PENDING`, and stop when a final result is returned.
 
 The cURL examples in the following sections show how to build and send each REST request. The responses show the data the merchant must process at each step.
 
@@ -610,18 +611,27 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/query \
   </Col>
 </Row>
 
+### Cancel a pending payment {{ id: 'gateway-cancel', tag: 'POST', label: '/gateway/transaction' }}
+
+While an ATH Móvil payment remains `PENDING`, the merchant can request its cancellation through [Operations on a transaction](/en/gateway/api/reference/transaction#transaction-request). Cancellation must be enabled for the service and uses the original `internalReference` returned when the payment was processed.
+
+When ATH Móvil approves the cancellation, the original transaction changes to `REJECTED` with reason `MC`. If cancellation returns `REJECTED` or `FAILED`, the original transaction remains `PENDING` and can still receive a result from ATH Móvil.
+
+Query the original `internalReference` again before retrying or starting another operation. If the payment has already been approved, use a reversal or refund as appropriate.
+
 ### Post-transaction operations {{ id: 'post-transaction-operations' }}
 
 ATH Móvil supports reversals and refunds through the general Gateway operations. Their availability depends on the transaction status and site configuration.
 
 To perform these operations, see [Operations on a transaction](/en/gateway/api/reference/transaction#transaction-request).
 
-Reversals must be performed before reconciliation. Once the transaction is reconciled, use a refund instead. A refund transaction cannot be reversed.
+Cancellation applies only while the payment remains `PENDING`. If the payment has already been approved, reversals must be performed before reconciliation and, once reconciled, a refund must be used instead. A refund transaction cannot be reversed.
 
 ## Restrictions and Considerations {{ id: 'validations' }}
 
 - **Asynchronous Gateway flow**: The merchant must implement API status polling until a final result is available.
 - **Pending state during approval**: The transaction remains pending while the user confirms the payment on their phone.
+- **Pending payment cancellation**: A failed or rejected cancellation response does not change the original transaction status; query it again before retrying.
 - **Regional availability**: ATH Móvil applies to operations in Puerto Rico.
 
 The processing request supports decimal amounts; `stateTax`, `municipalTax`, and `reducedStateTax` in `payment.amount.taxes`; and tips through `payment.amount.details` with `kind: "tip"`. The base amount remaining after subtracting these taxes and the tip must be greater than zero.
@@ -665,4 +675,9 @@ For test sites, the simulator determines its behavior from `payer.mobile`. Inter
 <details>
 <summary>Should I redirect the user in a Gateway integration?</summary>
 <p>Not in production. The user approves the charge from the ATH Móvil application, and the merchant queries the result using the internal reference. The redirection URL is provided only in sandbox to access the simulator.</p>
+</details>
+
+<details>
+<summary>When should I cancel, reverse, or refund a payment?</summary>
+<p>Request cancellation while the ATH Móvil payment remains <code>PENDING</code>. If it has already been approved, use a reversal before reconciliation or a refund after reconciliation.</p>
 </details>

--- a/src/pages/payments/external-redirects/ath-movil.mdx
+++ b/src/pages/payments/external-redirects/ath-movil.mdx
@@ -55,7 +55,7 @@ Además del teléfono, el backend del comercio envía las credenciales de autent
 2. El usuario ingresa el número de teléfono asociado a su cuenta ATH Móvil.
 3. El backend del comercio envía la solicitud a `POST /gateway/process`.
 4. ATH Móvil envía una notificación push al teléfono del usuario y la transacción queda en estado `PENDING`.
-5. El usuario aprueba o rechaza la solicitud desde la aplicación ATH Móvil.
+5. Mientras la transacción permanece `PENDING`, el usuario puede aprobarla o rechazarla desde la aplicación ATH Móvil; el comercio también puede solicitar su cancelación.
 6. El comercio consulta la transacción con el `internalReference` y actualiza su propia interfaz con el resultado final.
 
 ### Componentes visuales de referencia {{ id: 'visual-resources' }}
@@ -171,7 +171,8 @@ Utiliza la variante que mantenga mejor contraste con tu interfaz. Los archivos e
 1. Opcionalmente, consulta las capacidades de ATH Móvil mediante `POST /gateway/information`.
 2. Envía el cobro mediante `POST /gateway/process`.
 3. Conserva el `internalReference` de la respuesta inicial.
-4. Consulta `POST /gateway/query` mientras el estado sea `PENDING` y detente cuando recibas un resultado final.
+4. Si necesitas solicitar la cancelación de un pago que continúa `PENDING`, envía `action: "cancel"` a `POST /gateway/transaction`.
+5. Consulta `POST /gateway/query` mientras el estado sea `PENDING` y detente cuando recibas un resultado final.
 
 Los ejemplos cURL de las siguientes secciones muestran cómo construir y enviar cada petición REST. Las respuestas muestran los datos que el comercio debe procesar en cada paso.
 
@@ -610,18 +611,27 @@ curl -X "POST" https://api-co-dev.placetopay.ws/gateway/query \
   </Col>
 </Row>
 
+### Cancelar un pago pendiente {{ id: 'gateway-cancel', tag: 'POST', label: '/gateway/transaction' }}
+
+Mientras el pago ATH Móvil se encuentre en estado `PENDING`, el comercio puede solicitar su cancelación mediante [Operaciones sobre una transacción](/gateway/api/reference/transaction#transaction-request). La cancelación debe estar habilitada para el servicio y utiliza el `internalReference` original recibido al procesar el pago.
+
+Cuando ATH Móvil aprueba la cancelación, la transacción original pasa a `REJECTED` con razón `MC`. Si la cancelación devuelve `REJECTED` o `FAILED`, la transacción original permanece `PENDING` y todavía puede recibir un resultado desde ATH Móvil.
+
+Consulta nuevamente el `internalReference` original antes de reintentar o iniciar otra operación. Si el pago ya fue aprobado, utiliza un reverso o un reembolso según corresponda.
+
 ### Operaciones posteriores {{ id: 'post-transaction-operations' }}
 
 ATH Móvil permite realizar reversos y reembolsos mediante las operaciones generales de Gateway. Su disponibilidad depende del estado de la transacción y de la configuración del sitio.
 
 Para realizar estas operaciones, consulta [Operaciones sobre una transacción](/gateway/api/reference/transaction#transaction-request).
 
-Los reversos deben realizarse antes de la conciliación. Una vez conciliada la transacción, corresponde realizar un reembolso. Una transacción de reembolso no puede ser reversada.
+La cancelación aplica únicamente mientras el pago continúa `PENDING`. Si el pago ya fue aprobado, los reversos deben realizarse antes de la conciliación y, una vez conciliado, corresponde realizar un reembolso. Una transacción de reembolso no puede ser reversada.
 
 ## Restricciones y consideraciones {{ id: 'validations' }}
 
 - **Flujo asíncrono en Gateway**: El comercio debe implementar la consulta de estado por API hasta obtener un resultado final.
 - **Estado pendiente durante la aprobación**: La transacción permanece pendiente mientras el usuario confirma el pago en su teléfono.
+- **Cancelación de pagos pendientes**: Una respuesta fallida o rechazada de cancelación no cambia el estado de la transacción original; vuelve a consultarla antes de reintentar.
 - **Disponibilidad por región**: ATH Móvil aplica para operaciones en Puerto Rico.
 
 La petición de procesamiento admite montos decimales, los impuestos `stateTax`, `municipalTax` y `reducedStateTax` en `payment.amount.taxes`, y propinas mediante `payment.amount.details` con `kind: "tip"`. El monto base resultante después de restar estos impuestos y la propina debe ser mayor que cero.
@@ -665,4 +675,9 @@ En sitios de prueba, el simulador determina el comportamiento a partir de `payer
 <details>
 <summary>¿Debo redirigir al usuario en una integración Gateway?</summary>
 <p>No en producción. El usuario aprueba el cobro desde la aplicación ATH Móvil y el comercio consulta el resultado con la referencia interna. La URL de redirección solo se entrega en sandbox para acceder al simulador.</p>
+</details>
+
+<details>
+<summary>¿Cuándo debo cancelar, reversar o reembolsar un pago?</summary>
+<p>Solicita una cancelación mientras el pago ATH Móvil permanezca <code>PENDING</code>. Si el pago ya fue aprobado, utiliza un reverso antes de la conciliación o un reembolso después de la conciliación.</p>
 </details>


### PR DESCRIPTION
## Summary

Documents the remote cancellation flow for pending ATH Móvil payments through Gateway.

[Task 86e2rhnc8](https://app.clickup.com/t/86e2rhnc8)

## Changes

- Adds pending payment cancellation guidance to the ATH Móvil documentation.
- Explains when to use cancellation, reversal, or refund.
- Documents the behavior for approved, rejected, and failed cancellation attempts.
- Updates the Gateway OpenAPI description for `action: cancel`.
- Keeps Spanish and English documentation aligned.
