### PR TITLE
docs: update tpm reference lenght and optional email

### DIFF
--- a/src/pages/en/tpm/tokenization.mdx
+++ b/src/pages/en/tpm/tokenization.mdx
@@ -78,7 +78,7 @@ The file must be comma-separated and contain the columns in the specified order.
             </Property>
             <Property name="documentType" type="string" isRequired={false}>
                 Customer document type: `CI`, `RUC`, or `PPN`.
-                [See more](/gateway/document-types)
+                [See more](/en/gateway/document-types)
             </Property>
             <Property name="document" type="string" isRequired={false}>
                 Cardholder document number.

--- a/src/pages/en/tpm/tokenization.mdx
+++ b/src/pages/en/tpm/tokenization.mdx
@@ -259,7 +259,7 @@ The resulting file replaces the card information with the tokenized identifiers 
     <Col sticky>
 
         ```txt {{ 'title': 'Output file structure example' }}
-        Reference,Token,Subtoken
+        Referencia,Token,Subtoken
         REF001,abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890,1234567890123456
         ```
 

--- a/src/pages/en/tpm/tokenization.mdx
+++ b/src/pages/en/tpm/tokenization.mdx
@@ -67,7 +67,7 @@ The file must be comma-separated and contain the columns in the specified order.
             <Property name="reference" type="string">
                 Record identifier code provided by the customer to link it to their database. It must be unique per record.
                 - Minimum length: `1`
-                - Maximum length: `32`
+                - Maximum length: `65`
             </Property>
             <Property name="pan" type="string">
                 Full card number, without spaces.
@@ -99,7 +99,7 @@ The file must be comma-separated and contain the columns in the specified order.
                 Cardholder phone number.
                 - Maximum length: `30`
             </Property>
-            <Property name="email" type="string">
+            <Property name="email" type="string" isRequired={false}>
                 Cardholder email address.
                 - Maximum length: `80`
             </Property>
@@ -181,7 +181,7 @@ The file must be comma-separated and contain the columns in the specified order.
             <Property name="reference" type="string">
                  Record identifier code provided by the customer to link it to their database. It must be unique per record.
                  - Minimum length: `1`
-                 - Maximum length: `32`
+                 - Maximum length: `65`
             </Property>
             <Property name="accountNumber" type="string">
                 Full account number, without spaces.
@@ -206,7 +206,7 @@ The file must be comma-separated and contain the columns in the specified order.
                 Cardholder mobile phone number.
                 - Maximum length: `30`
             </Property>
-            <Property name="email" type="string">
+            <Property name="email" type="string" isRequired={false}>
                 Cardholder email address.
                 - Maximum length: `80`
             </Property>

--- a/src/pages/en/tpm/tokenization.mdx
+++ b/src/pages/en/tpm/tokenization.mdx
@@ -78,6 +78,7 @@ The file must be comma-separated and contain the columns in the specified order.
             </Property>
             <Property name="documentType" type="string" isRequired={false}>
                 Customer document type: `CI`, `RUC`, or `PPN`.
+                [See more](/gateway/document-types)
             </Property>
             <Property name="document" type="string" isRequired={false}>
                 Cardholder document number.
@@ -120,7 +121,7 @@ The file must be comma-separated and contain the columns in the specified order.
 
         ```txt {{ 'title': 'Input file structure example' }}
         reference,pan,expiration,documentType,document,name,surname,cellphone,phone,email,address,city,country
-        REF001,4111111111111111,12/28,CI,1234567890,Name,LastName,3000000000,6000000,customer@example.com,Street 1,Medellin,CO
+        REF001,4111111111111111,12/28,CI,1234567890,Name,Surname,3000000000,6000000,customer@example.com,Street 1,Medellin,CO
         ```
 
     </Col>
@@ -155,7 +156,7 @@ The resulting file replaces the card information with the tokenized identifiers 
     <Col sticky>
 
         ```txt {{ 'title': 'Output file structure example' }}
-        Reference,Token,Subtoken
+        Referencia,Token,Subtoken
         REF001,abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890,1234567890123456
         ```
 
@@ -227,7 +228,7 @@ The file must be comma-separated and contain the columns in the specified order.
 
         ```txt {{ 'title': 'Input file structure example' }}
         reference,accountNumber,bankCode,accountType,name,surname,cellphone,email,address,city,country
-        REF001,123456789,221571415,CCD,Name,Apellido,LastName,6000000,customer@example.com,Street 1,Medellin,PR
+        REF001,123456789,221571415,CCD,Name,Surname,6000000,customer@example.com,Street 1,Medellin,PR
         ```
 
     </Col>

--- a/src/pages/tpm/tokenization.mdx
+++ b/src/pages/tpm/tokenization.mdx
@@ -68,7 +68,7 @@ El archivo debe estar separado por comas y contener las columnas en el orden ind
             <Property name="reference" type="string">
                 Código identificador del registro, provisto por el cliente para relacionarlo con su base de datos. Debe ser único por registro.
                 - Longitud mínima: `1`
-                - Longitud máxima: `32`
+                - Longitud máxima: `65`
             </Property>
             <Property name="pan" type="string">
                 Número completo de la tarjeta, sin espacios.
@@ -100,7 +100,7 @@ El archivo debe estar separado por comas y contener las columnas en el orden ind
                 Número telefónico del titular.
                 - Longitud máxima: `30`
             </Property>
-            <Property name="email" type="string">
+            <Property name="email" type="string" isRequired={false}>
                 Correo electrónico del titular.
                 - Longitud máxima: `80`
             </Property>
@@ -182,7 +182,7 @@ El archivo debe estar separado por comas y contener las columnas en el orden ind
             <Property name="reference" type="string">
                 Código identificador del registro, provisto por el cliente para relacionarlo con su base de datos. Debe ser único por registro.
                 - Longitud mínima: `1`
-                - Longitud máxima: `32`
+                - Longitud máxima: `65`
             </Property>
             <Property name="accountNumber" type="string">
                 Número completo de la cuenta, sin espacios.
@@ -207,7 +207,7 @@ El archivo debe estar separado por comas y contener las columnas en el orden ind
                 Número de celular del titular.
                  - Longitud máxima: `30`
             </Property>
-            <Property name="email" type="string">
+            <Property name="email" type="string" isRequired={false}>
                 Correo electrónico del titular.
                  - Longitud máxima: `80`
             </Property>

--- a/src/pages/tpm/tokenization.mdx
+++ b/src/pages/tpm/tokenization.mdx
@@ -79,6 +79,7 @@ El archivo debe estar separado por comas y contener las columnas en el orden ind
             </Property>
             <Property name="documentType" type="string" isRequired={false}>
                 Tipo de documento del cliente: `CI`, `RUC` o `PPN`.
+                [Conoce más](/gateway/document-types)
             </Property>
             <Property name="document" type="string" isRequired={false}>
                 Número de documento del titular.


### PR DESCRIPTION
Task: https://app.clickup.com/t/31051369/86e2x0kf2
Both changes apply for card tokenization and account tokenization
Lenght from 32 to 65
<img width="550" height="201" alt="image" src="https://github.com/user-attachments/assets/145e988d-35a1-48b7-8a13-d493161f8a5e" />
<img width="542" height="217" alt="image" src="https://github.com/user-attachments/assets/993f2a28-ef9b-4fda-9758-488c420d792d" />

Email was required, now is optional
<img width="570" height="173" alt="image" src="https://github.com/user-attachments/assets/31938c06-c1b5-41a4-b950-e05b315179c5" />
<img width="570" height="165" alt="image" src="https://github.com/user-attachments/assets/369b914a-969d-42e7-bf47-0f94a62fb425" />
