### PR TITLE
docs: reuse Settings-Payment-Method and add threeDSProvider key

### DIFF
--- a/src/assets/apis/core/en.yaml
+++ b/src/assets/apis/core/en.yaml
@@ -16459,7 +16459,15 @@ components:
           x-stoplight:
             id: u3eawfq9u65df
           description: Determines whether it is an e-commerce merchant
+        threeDSProvider:
+          type: string
+          default: placetopay
+          description: Provider that resolves the 3DS authentication of the payment method, in lowercase; if the key is not sent, placetopay is used
+          enum:
+            - placetopay
+            - seglan
         3DSVersion:
+          type: string
           x-stoplight:
             id: tg6u5y0egr2td
           description: Determines the 3DS version

--- a/src/assets/apis/core/es.yaml
+++ b/src/assets/apis/core/es.yaml
@@ -16544,7 +16544,15 @@ components:
           x-stoplight:
             id: u3eawfq9u65df
           description: Determina si es un comercio electrónico
+        threeDSProvider:
+          type: string
+          default: placetopay
+          description: Proveedor que resuelve la autenticación 3DS del medio de pago, en minúsculas; si la clave no se envía, se usa placetopay
+          enum:
+            - placetopay
+            - seglan
         3DSVersion:
+          type: string
           x-stoplight:
             id: tg6u5y0egr2td
           description: Determina la versión de 3DS

--- a/src/assets/apis/onboarding/en.yaml
+++ b/src/assets/apis/onboarding/en.yaml
@@ -1303,23 +1303,7 @@ components:
           type: [object, 'null']
           description: Reglas de crédito del medio de pago. Hasta 4096 bytes serializados.
         settings:
-          type: object
-          description: |
-            Configuración específica del proveedor. Los nombres de las claves son libres —no hay
-            catálogo que los declare—, así que un error de escritura se guarda sin detectarse.
-
-            Hasta 64 claves y 8192 bytes. Cada nombre admite 30 caracteres y debe ser único
-            ignorando mayúsculas. Los valores pueden ser cadena, número o booleano; un objeto o una
-            lista se rechazan. En una actualización, una clave enviada con `null` o cadena vacía se
-            elimina.
-
-            Para los medios de pago cuyo proveedor es **CREDIBANCO**, las claves `retailCode`,
-            `terminalNumber`, `username` y `password` se rechazan: crea el certificado en el Panel y
-            envía el `pfxID` resultante. Es el único proveedor con este tratamiento.
-          additionalProperties:
-            type: [string, number, boolean, 'null']
-          example:
-            pfxID: '1'
+          $ref: '#/components/schemas/Settings-Payment-Method'
 
     SitePaymentMethod:
       title: SitePaymentMethod
@@ -1404,14 +1388,78 @@ components:
           type: [object, 'null']
           description: Si se omite, se heredan las del comercio.
         settings:
-          type: object
-          description: |
-            Ajustes propios del sitio. Se fusionan con los existentes: una clave enviada con `null` o
-            cadena vacía se elimina, y una que no se envía se conserva.
+          $ref: '#/components/schemas/Settings-Payment-Method'
 
-            En una transacción, un ajuste del sitio prevalece sobre el del comercio.
-          additionalProperties:
-            type: [string, number, boolean, 'null']
+    Settings-Payment-Method:
+      title: Settings-Payment-Method
+      type: object
+      description: |
+        Configuración específica del proveedor del medio de pago. Las claves listadas son las de uso
+        habitual, pero los nombres son libres.
+
+        Los ajustes se fusionan y una clave enviada con `null` o cadena vacía se elimina. Ver
+        [El bloque settings](/onboarding/payment-methods#settings-block).
+      properties:
+        merchantCode:
+          type: string
+          description: Código de entidad.
+        terminalNumber:
+          type: string
+          description: Número de terminal del medio de pago.
+        MID:
+          type: string
+          description: ID de comerciante.
+        RUC:
+          type: string
+          description: Registro único de contribuyente.
+        username:
+          type: string
+          maxLength: 30
+          description: Usuario de la terminal.
+        password:
+          type: string
+          maxLength: 30
+          description: Contraseña de la terminal.
+        retailCode:
+          type: string
+          maxLength: 10
+          description: Código único de venta.
+        terminalLocation:
+          type: string
+          description: Determina la ubicación de la terminal.
+        serviceCode:
+          type: string
+          description: Código que representa el servicio del comercio.
+        isEcommerce:
+          type: boolean
+          description: Determina si es un comercio electrónico.
+        threeDSProvider:
+          type: string
+          default: placetopay
+          description: |
+            Proveedor que resuelve la autenticación 3DS del medio de pago, en minúsculas. Si la
+            clave no se envía, se usa `placetopay`.
+          enum:
+            - placetopay
+            - seglan
+        3DSVersion:
+          type: string
+          description: Determina la versión de 3DS.
+          enum:
+            - v1
+            - v2
+        3DSApiKey:
+          type: string
+          maxLength: 380
+          description: 3DS API key.
+        aggregatorModel:
+          type: boolean
+          default: false
+          description: Determina si es modelo agregador (_PSE_).
+      additionalProperties:
+        type: [string, number, boolean, 'null']
+      example:
+        pfxID: '1'
 
     Site:
       title: Site

--- a/src/assets/apis/onboarding/es.yaml
+++ b/src/assets/apis/onboarding/es.yaml
@@ -1303,23 +1303,7 @@ components:
           type: [object, 'null']
           description: Reglas de crédito del medio de pago. Hasta 4096 bytes serializados.
         settings:
-          type: object
-          description: |
-            Configuración específica del proveedor. Los nombres de las claves son libres —no hay
-            catálogo que los declare—, así que un error de escritura se guarda sin detectarse.
-
-            Hasta 64 claves y 8192 bytes. Cada nombre admite 30 caracteres y debe ser único
-            ignorando mayúsculas. Los valores pueden ser cadena, número o booleano; un objeto o una
-            lista se rechazan. En una actualización, una clave enviada con `null` o cadena vacía se
-            elimina.
-
-            Para los medios de pago cuyo proveedor es **CREDIBANCO**, las claves `retailCode`,
-            `terminalNumber`, `username` y `password` se rechazan: crea el certificado en el Panel y
-            envía el `pfxID` resultante. Es el único proveedor con este tratamiento.
-          additionalProperties:
-            type: [string, number, boolean, 'null']
-          example:
-            pfxID: '1'
+          $ref: '#/components/schemas/Settings-Payment-Method'
 
     SitePaymentMethod:
       title: SitePaymentMethod
@@ -1404,14 +1388,78 @@ components:
           type: [object, 'null']
           description: Si se omite, se heredan las del comercio.
         settings:
-          type: object
-          description: |
-            Ajustes propios del sitio. Se fusionan con los existentes: una clave enviada con `null` o
-            cadena vacía se elimina, y una que no se envía se conserva.
+          $ref: '#/components/schemas/Settings-Payment-Method'
 
-            En una transacción, un ajuste del sitio prevalece sobre el del comercio.
-          additionalProperties:
-            type: [string, number, boolean, 'null']
+    Settings-Payment-Method:
+      title: Settings-Payment-Method
+      type: object
+      description: |
+        Configuración específica del proveedor del medio de pago. Las claves listadas son las de uso
+        habitual, pero los nombres son libres.
+
+        Los ajustes se fusionan y una clave enviada con `null` o cadena vacía se elimina. Ver
+        [El bloque settings](/onboarding/payment-methods#settings-block).
+      properties:
+        merchantCode:
+          type: string
+          description: Código de entidad.
+        terminalNumber:
+          type: string
+          description: Número de terminal del medio de pago.
+        MID:
+          type: string
+          description: ID de comerciante.
+        RUC:
+          type: string
+          description: Registro único de contribuyente.
+        username:
+          type: string
+          maxLength: 30
+          description: Usuario de la terminal.
+        password:
+          type: string
+          maxLength: 30
+          description: Contraseña de la terminal.
+        retailCode:
+          type: string
+          maxLength: 10
+          description: Código único de venta.
+        terminalLocation:
+          type: string
+          description: Determina la ubicación de la terminal.
+        serviceCode:
+          type: string
+          description: Código que representa el servicio del comercio.
+        isEcommerce:
+          type: boolean
+          description: Determina si es un comercio electrónico.
+        threeDSProvider:
+          type: string
+          default: placetopay
+          description: |
+            Proveedor que resuelve la autenticación 3DS del medio de pago, en minúsculas. Si la
+            clave no se envía, se usa `placetopay`.
+          enum:
+            - placetopay
+            - seglan
+        3DSVersion:
+          type: string
+          description: Determina la versión de 3DS.
+          enum:
+            - v1
+            - v2
+        3DSApiKey:
+          type: string
+          maxLength: 380
+          description: 3DS API key.
+        aggregatorModel:
+          type: boolean
+          default: false
+          description: Determina si es modelo agregador (_PSE_).
+      additionalProperties:
+        type: [string, number, boolean, 'null']
+      example:
+        pfxID: '1'
 
     Site:
       title: Site


### PR DESCRIPTION
## Qué cambia

En Onboarding, `paymentMethods[].settings` y `sites[].paymentMethods[].settings` eran objetos opacos: el lector no veía ninguna clave. Ahora referencian `Settings-Payment-Method`, el objeto que ya existía en el spec de Core, así que la referencia despliega las claves en los cuatro puntos (comercio y sitio × POST y PUT).

Se añade además la clave nueva `threeDSProvider` (`placetopay` | `seglan`, por defecto `placetopay`) a los dos specs.

## Decisiones que conviene conocer al revisar

- **El objeto se duplica en Onboarding en vez de referenciarse con `$ref` cruzado a `core/*.yaml`.** Se probó el ref cruzado y funciona, pero `ApiReader.dereferenceSchema` descarta las claves hermanas de un `$ref`, así que Onboarding perdería su descripción propia del bloque, y `SwaggerParser.bundle()` no crea el componente con su nombre: lo inserta inline en el primer uso y convierte el segundo en un puntero posicional. Las dos copias quedan alineadas — mismas 14 claves, mismo orden, sin diferencias de `type`, `enum`, `default` ni `maxLength`.
- **La descripción del bloque en Onboarding se resume de 17 a 4 líneas** y enlaza a `/onboarding/payment-methods#settings-block`, donde esas reglas ya estaban explicadas con más detalle.
- **`3DSVersion` en Core no declaraba `type`** y se renderizaba con la columna de tipo en blanco. Se corrige.
- **`onboarding/en.yaml` sigue byte-idéntico a `es.yaml`**, porque la traducción EN de ese namespace está pendiente y sus páginas llevan `<MissingTranslationBanner />`. En Core, que sí está traducido, la clave nueva va en inglés.

## Verificación

Ejecutando el pipeline real (`dereferenceOpenapi` + `dereferenceSchema`) sobre los 12 puntos de render afectados — 4 en Onboarding y 8 en Core, ES y EN: todos resuelven con 14 claves. `generate:api-downloads`, `generate:search-index` y `scan:sensitive` pasan.