### PR TITLE
docs: add POS_AIR to the Onboarding site type vocabulary

### DIFF
--- a/src/assets/apis/onboarding/en.yaml
+++ b/src/assets/apis/onboarding/en.yaml
@@ -1516,9 +1516,10 @@ components:
           example: Acme
         type:
           type: string
-          enum: [POS, INT, IVR, REC, ONE]
+          enum: [POS, INT, IVR, REC, ONE, POS_AIR]
           description: |
-            Canal del sitio: punto de venta, internet, telefónico, recurrente o pago único.
+            Canal del sitio: punto de venta, internet, telefónico, recurrente, pago único o punto de
+            venta de aerolínea.
           example: INT
         category:
           type: string

--- a/src/assets/apis/onboarding/es.yaml
+++ b/src/assets/apis/onboarding/es.yaml
@@ -1516,9 +1516,10 @@ components:
           example: Acme
         type:
           type: string
-          enum: [POS, INT, IVR, REC, ONE]
+          enum: [POS, INT, IVR, REC, ONE, POS_AIR]
           description: |
-            Canal del sitio: punto de venta, internet, telefónico, recurrente o pago único.
+            Canal del sitio: punto de venta, internet, telefónico, recurrente, pago único o punto de
+            venta de aerolínea.
           example: INT
         category:
           type: string

--- a/src/pages/en/onboarding/api/changelog.mdx
+++ b/src/pages/en/onboarding/api/changelog.mdx
@@ -16,6 +16,14 @@ conviene conocer para leer esta lista:
 - **Pueden aparecer códigos de fallo nuevos** en `status.reason`. Deja siempre un caso por defecto al
   interpretarlo.
 
+## 2026-08-24
+
+### Nuevo:
+
+- `sites[].type` admite el valor `POS_AIR`, punto de venta de aerolínea, además de los cinco que ya
+  aceptaba. Lo reconocen tanto la creación como la actualización de un comercio, y no cambia nada
+  más del contrato: un sitio de este tipo se declara y opera como cualquier otro.
+
 ## 2026-08-17
 
 ### Nuevo:

--- a/src/pages/en/onboarding/sites.mdx
+++ b/src/pages/en/onboarding/sites.mdx
@@ -57,7 +57,7 @@ Como el `login` no distingue mayúsculas, `ACME` y `acme` son el mismo identific
         Nombre que ve el comprador durante el pago.
       </Property>
       <Property name="type" type="string" isRequired={true}>
-        Canal del sitio: `INT` (internet), `POS` (punto de venta), `IVR` (telefónico), `REC` (recurrente) u `ONE` (pago único).
+        Canal del sitio: `INT` (internet), `POS` (punto de venta), `IVR` (telefónico), `REC` (recurrente), `ONE` (pago único) o `POS_AIR` (punto de venta de aerolínea).
       </Property>
       <Property name="category" type="string" isRequired={true}>
         Categoría de operación del sitio.

--- a/src/pages/onboarding/api/changelog.mdx
+++ b/src/pages/onboarding/api/changelog.mdx
@@ -14,6 +14,14 @@ conviene conocer para leer esta lista:
 - **Pueden aparecer códigos de fallo nuevos** en `status.reason`. Deja siempre un caso por defecto al
   interpretarlo.
 
+## 2026-08-24
+
+### Nuevo:
+
+- `sites[].type` admite el valor `POS_AIR`, punto de venta de aerolínea, además de los cinco que ya
+  aceptaba. Lo reconocen tanto la creación como la actualización de un comercio, y no cambia nada
+  más del contrato: un sitio de este tipo se declara y opera como cualquier otro.
+
 ## 2026-08-17
 
 ### Nuevo:

--- a/src/pages/onboarding/sites.mdx
+++ b/src/pages/onboarding/sites.mdx
@@ -55,7 +55,7 @@ Como el `login` no distingue mayúsculas, `ACME` y `acme` son el mismo identific
         Nombre que ve el comprador durante el pago.
       </Property>
       <Property name="type" type="string" isRequired={true}>
-        Canal del sitio: `INT` (internet), `POS` (punto de venta), `IVR` (telefónico), `REC` (recurrente) u `ONE` (pago único).
+        Canal del sitio: `INT` (internet), `POS` (punto de venta), `IVR` (telefónico), `REC` (recurrente), `ONE` (pago único) o `POS_AIR` (punto de venta de aerolínea).
       </Property>
       <Property name="category" type="string" isRequired={true}>
         Categoría de operación del sitio.


### PR DESCRIPTION
## Qué cambia

`sites[].type` admite `POS_AIR` —punto de venta de aerolínea—, además de `POS`, `INT`, `IVR`, `REC` y `ONE`. El valor lo aceptan tanto `POST /api/merchants` como `PUT /api/merchants/{merchantId}`, y no cambia nada más del contrato: mismos códigos de respuesta, misma forma del `status`, mismo flujo asíncrono.

Viene de api-onboarding, donde el enum `SiteType` replica la columna `tp14_customers_sites.cp14_type` de `co_placetopay`, hoy `enum('POS','INT','IVR','REC','ONE','POS_AIR')`.

## Verificación

`scan:sensitive` y `check:links` (578 páginas) pasan. Los cuatro MDX compilan con `@mdx-js/mdx`. El spec dereferencia sin errores y ambos endpoints resuelven al enum de seis valores.

Nota: `SwaggerParser.validate` falla sobre este spec en `servers[0].variables.urlBase`, pero comprobé que ya fallaba en `main` — es preexistente y ajeno a este cambio.
