### PR TITLE
docs(onboarding): use PATCH for the merchant update endpoint

### DIFF
--- a/src/assets/apis/onboarding/en.yaml
+++ b/src/assets/apis/onboarding/en.yaml
@@ -139,7 +139,7 @@ paths:
           type: integer
           minimum: 1
           example: 18
-    put:
+    patch:
       summary: Actualizar un comercio
       operationId: update-merchant
       description: |

--- a/src/assets/apis/onboarding/es.yaml
+++ b/src/assets/apis/onboarding/es.yaml
@@ -139,7 +139,7 @@ paths:
           type: integer
           minimum: 1
           example: 18
-    put:
+    patch:
       summary: Actualizar un comercio
       operationId: update-merchant
       description: |

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -36,6 +36,7 @@ const valueColorMap = {
   get: 'primary',
   post: 'sky',
   put: 'amber',
+  patch: 'amber',
   delete: 'rose',
 }
 

--- a/src/pages/en/onboarding/api/changelog.mdx
+++ b/src/pages/en/onboarding/api/changelog.mdx
@@ -18,6 +18,14 @@ conviene conocer para leer esta lista:
 
 ## 2026-08-24
 
+### Cambió:
+
+- **La actualización de un comercio usa `PATCH`, no `PUT`.** La ruta es ahora
+  `PATCH /api/merchants/{merchantId}`. El verbo describe lo que el endpoint siempre hizo: escribir
+  solo los campos que el cuerpo nombra, en lugar de reemplazar el comercio entero. Nada más cambia —
+  la misma URL, el mismo cuerpo, los mismos headers, los mismos códigos de respuesta y el mismo
+  flujo de consulta del proceso. La creación sigue siendo `POST /api/merchants`.
+
 ### Nuevo:
 
 - `sites[].type` admite el valor `POS_AIR`, punto de venta de aerolínea, además de los cinco que ya

--- a/src/pages/en/onboarding/api/reference/merchants.mdx
+++ b/src/pages/en/onboarding/api/reference/merchants.mdx
@@ -104,7 +104,7 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
 
 ---
 
-## Actualizar un comercio {{ id: 'update-a-merchant', tag: 'PUT', label: '/api/merchants/{merchantId}' }}
+## Actualizar un comercio {{ id: 'update-a-merchant', tag: 'PATCH', label: '/api/merchants/{merchantId}' }}
 
 <Row>
   <Col>
@@ -118,23 +118,23 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
 
     <ApiReader
       path="/api/merchants/{merchantId}"
-      method="put"
+      method="patch"
       type="header"
       api={props.refs}
     />
 
     <ApiReader
       path="/api/merchants/{merchantId}"
-      method="put"
+      method="patch"
       api={props.refs}
     />
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Solicitud" tag="PUT" label="/api/merchants/{merchantId}">
+    <CodeGroup title="Solicitud" tag="PATCH" label="/api/merchants/{merchantId}">
 
     ```bash {{ title: 'cURL' }}
-    curl --request PUT \
+    curl --request PATCH \
       --url '{URL_BASE}/api/merchants/18' \
       --header 'Accept: application/json' \
       --header 'Content-Type: application/json' \
@@ -151,7 +151,7 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   <Col>
     <ApiReader
       path="/api/merchants/{merchantId}"
-      method="put"
+      method="patch"
       type="response"
       api={props.refs}
     />

--- a/src/pages/en/onboarding/authentication.mdx
+++ b/src/pages/en/onboarding/authentication.mdx
@@ -81,7 +81,7 @@ Un token lleva asociados uno o varios permisos, y cada operación exige el suyo.
 | Permiso | Habilita | Operación |
 |---|---|---|
 | `onboarding:create` | `POST /api/merchants` | [Crear un comercio](/en/onboarding/create-merchant) |
-| `onboarding:update` | `PUT /api/merchants/{merchantId}` | [Actualizar un comercio](/en/onboarding/update-merchant) |
+| `onboarding:update` | `PATCH /api/merchants/{merchantId}` | [Actualizar un comercio](/en/onboarding/update-merchant) |
 | `onboarding:read` | `GET /api/processes/{processId}` | [Consultar el proceso](/en/onboarding/process-status) |
 
 Si tu token no incluye el permiso que la operación exige, la respuesta es `403`.

--- a/src/pages/en/onboarding/merchant-data.mdx
+++ b/src/pages/en/onboarding/merchant-data.mdx
@@ -307,8 +307,8 @@ El identificador del comercio **no viaja en el cuerpo**. Estas dos grafías resp
 
 | Campo | Por qué | Dónde va |
 |---|---|---|
-| `id` | El comercio se identifica por la URL | En la ruta del `PUT` |
-| `merchantId` | Igual que el anterior | En la ruta del `PUT` |
+| `id` | El comercio se identifica por la URL | En la ruta del `PATCH` |
+| `merchantId` | Igual que el anterior | En la ruta del `PATCH` |
 
 Se rechazan explícitamente en lugar de ignorarse: un campo que simplemente se descarta es peor que uno que se rechaza, porque quien llama se queda creyendo que direccionó otro recurso.
 

--- a/src/pages/en/onboarding/site-integrations.mdx
+++ b/src/pages/en/onboarding/site-integrations.mdx
@@ -76,7 +76,7 @@ El límite de tamaño del bloque es **propio del sitio** y no cuenta contra el d
 Tres consecuencias que conviene conocer, porque ninguna se puede devolver como error:
 
 1. **Depende solo del tipo.** Un `notifier` con `enabled: false` reescribe la URL igual que uno habilitado. Basta con que el elemento exista.
-2. **Gana sobre lo que envíes en el mismo cuerpo.** Si en ese mismo `PUT` envías `sites[].integration.notificationUrl`, ese valor **se descarta** y prevalece la URL derivada.
+2. **Gana sobre lo que envíes en el mismo cuerpo.** Si en ese mismo `PATCH` envías `sites[].integration.notificationUrl`, ese valor **se descarta** y prevalece la URL derivada.
 3. **Una edición manual posterior la cambia.** Si alguien guarda ese sitio desde el back office, la URL pasará a derivarse de otra forma y apuntará a otro destino.
 
 Si tu integración depende de recibir notificaciones de transacción en una URL propia, **no envíes un `notifier` a ese sitio**.

--- a/src/pages/en/onboarding/update-merchant.mdx
+++ b/src/pages/en/onboarding/update-merchant.mdx
@@ -1,18 +1,18 @@
 export const description =
-  'Actualiza un comercio existente con PUT /api/merchants/{merchantId} enviando solo los campos que quieres cambiar.'
+  'Actualiza un comercio existente con PATCH /api/merchants/{merchantId} enviando solo los campos que quieres cambiar.'
 
 <MissingTranslationBanner />
 
 # Actualizar un comercio
 
-`PUT /api/merchants/{merchantId}` modifica un comercio que ya existe. Como la creación, es asíncrono: valida, acepta con `202` y devuelve un `processId`.
+`PATCH /api/merchants/{merchantId}` modifica un comercio que ya existe. Como la creación, es asíncrono: valida, acepta con `202` y devuelve un `processId`.
 
 ## La petición {{ id: 'the-request' }}
 
-<CodeGroup title="Solicitud" tag="PUT" label="/api/merchants/{merchantId}">
+<CodeGroup title="Solicitud" tag="PATCH" label="/api/merchants/{merchantId}">
 
 ```bash {{ title: 'cURL' }}
-curl --request PUT \
+curl --request PATCH \
   --url '{URL_BASE}/api/merchants/18' \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \

--- a/src/pages/onboarding/api/changelog.mdx
+++ b/src/pages/onboarding/api/changelog.mdx
@@ -16,6 +16,14 @@ conviene conocer para leer esta lista:
 
 ## 2026-08-24
 
+### Cambió:
+
+- **La actualización de un comercio usa `PATCH`, no `PUT`.** La ruta es ahora
+  `PATCH /api/merchants/{merchantId}`. El verbo describe lo que el endpoint siempre hizo: escribir
+  solo los campos que el cuerpo nombra, en lugar de reemplazar el comercio entero. Nada más cambia —
+  la misma URL, el mismo cuerpo, los mismos headers, los mismos códigos de respuesta y el mismo
+  flujo de consulta del proceso. La creación sigue siendo `POST /api/merchants`.
+
 ### Nuevo:
 
 - `sites[].type` admite el valor `POS_AIR`, punto de venta de aerolínea, además de los cinco que ya

--- a/src/pages/onboarding/api/reference/merchants.mdx
+++ b/src/pages/onboarding/api/reference/merchants.mdx
@@ -102,7 +102,7 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
 
 ---
 
-## Actualizar un comercio {{ id: 'update-a-merchant', tag: 'PUT', label: '/api/merchants/{merchantId}' }}
+## Actualizar un comercio {{ id: 'update-a-merchant', tag: 'PATCH', label: '/api/merchants/{merchantId}' }}
 
 <Row>
   <Col>
@@ -116,23 +116,23 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
 
     <ApiReader
       path="/api/merchants/{merchantId}"
-      method="put"
+      method="patch"
       type="header"
       api={props.refs}
     />
 
     <ApiReader
       path="/api/merchants/{merchantId}"
-      method="put"
+      method="patch"
       api={props.refs}
     />
 
   </Col>
   <Col sticky>
-    <CodeGroup title="Solicitud" tag="PUT" label="/api/merchants/{merchantId}">
+    <CodeGroup title="Solicitud" tag="PATCH" label="/api/merchants/{merchantId}">
 
     ```bash {{ title: 'cURL' }}
-    curl --request PUT \
+    curl --request PATCH \
       --url '{URL_BASE}/api/merchants/18' \
       --header 'Accept: application/json' \
       --header 'Content-Type: application/json' \
@@ -149,7 +149,7 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   <Col>
     <ApiReader
       path="/api/merchants/{merchantId}"
-      method="put"
+      method="patch"
       type="response"
       api={props.refs}
     />

--- a/src/pages/onboarding/authentication.mdx
+++ b/src/pages/onboarding/authentication.mdx
@@ -79,7 +79,7 @@ Un token lleva asociados uno o varios permisos, y cada operación exige el suyo.
 | Permiso | Habilita | Operación |
 |---|---|---|
 | `onboarding:create` | `POST /api/merchants` | [Crear un comercio](/onboarding/create-merchant) |
-| `onboarding:update` | `PUT /api/merchants/{merchantId}` | [Actualizar un comercio](/onboarding/update-merchant) |
+| `onboarding:update` | `PATCH /api/merchants/{merchantId}` | [Actualizar un comercio](/onboarding/update-merchant) |
 | `onboarding:read` | `GET /api/processes/{processId}` | [Consultar el proceso](/onboarding/process-status) |
 
 Si tu token no incluye el permiso que la operación exige, la respuesta es `403`.

--- a/src/pages/onboarding/merchant-data.mdx
+++ b/src/pages/onboarding/merchant-data.mdx
@@ -305,8 +305,8 @@ El identificador del comercio **no viaja en el cuerpo**. Estas dos grafías resp
 
 | Campo | Por qué | Dónde va |
 |---|---|---|
-| `id` | El comercio se identifica por la URL | En la ruta del `PUT` |
-| `merchantId` | Igual que el anterior | En la ruta del `PUT` |
+| `id` | El comercio se identifica por la URL | En la ruta del `PATCH` |
+| `merchantId` | Igual que el anterior | En la ruta del `PATCH` |
 
 Se rechazan explícitamente en lugar de ignorarse: un campo que simplemente se descarta es peor que uno que se rechaza, porque quien llama se queda creyendo que direccionó otro recurso.
 

--- a/src/pages/onboarding/site-integrations.mdx
+++ b/src/pages/onboarding/site-integrations.mdx
@@ -74,7 +74,7 @@ El límite de tamaño del bloque es **propio del sitio** y no cuenta contra el d
 Tres consecuencias que conviene conocer, porque ninguna se puede devolver como error:
 
 1. **Depende solo del tipo.** Un `notifier` con `enabled: false` reescribe la URL igual que uno habilitado. Basta con que el elemento exista.
-2. **Gana sobre lo que envíes en el mismo cuerpo.** Si en ese mismo `PUT` envías `sites[].integration.notificationUrl`, ese valor **se descarta** y prevalece la URL derivada.
+2. **Gana sobre lo que envíes en el mismo cuerpo.** Si en ese mismo `PATCH` envías `sites[].integration.notificationUrl`, ese valor **se descarta** y prevalece la URL derivada.
 3. **Una edición manual posterior la cambia.** Si alguien guarda ese sitio desde el back office, la URL pasará a derivarse de otra forma y apuntará a otro destino.
 
 Si tu integración depende de recibir notificaciones de transacción en una URL propia, **no envíes un `notifier` a ese sitio**.

--- a/src/pages/onboarding/update-merchant.mdx
+++ b/src/pages/onboarding/update-merchant.mdx
@@ -1,16 +1,16 @@
 export const description =
-  'Actualiza un comercio existente con PUT /api/merchants/{merchantId} enviando solo los campos que quieres cambiar.'
+  'Actualiza un comercio existente con PATCH /api/merchants/{merchantId} enviando solo los campos que quieres cambiar.'
 
 # Actualizar un comercio
 
-`PUT /api/merchants/{merchantId}` modifica un comercio que ya existe. Como la creación, es asíncrono: valida, acepta con `202` y devuelve un `processId`.
+`PATCH /api/merchants/{merchantId}` modifica un comercio que ya existe. Como la creación, es asíncrono: valida, acepta con `202` y devuelve un `processId`.
 
 ## La petición {{ id: 'the-request' }}
 
-<CodeGroup title="Solicitud" tag="PUT" label="/api/merchants/{merchantId}">
+<CodeGroup title="Solicitud" tag="PATCH" label="/api/merchants/{merchantId}">
 
 ```bash {{ title: 'cURL' }}
-curl --request PUT \
+curl --request PATCH \
   --url '{URL_BASE}/api/merchants/18' \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \


### PR DESCRIPTION
## Qué cambia

La actualización de un comercio en Onboarding se documenta ahora como `PATCH /api/merchants/{merchantId}`, donde antes decía `PUT`. Cambia solo el verbo: la misma URL, el mismo cuerpo, los mismos headers (`Authorization`, `Idempotency-Key`), los mismos códigos de respuesta y el mismo flujo asíncrono de consulta del proceso. La creación no se toca y sigue siendo `POST /api/merchants`.

`PATCH` describe lo que el endpoint hace: escribe **solo los campos que el cuerpo nombra** y deja intacto el resto del comercio, incluidas las colecciones anidadas. `PUT` prometía un reemplazo total del recurso que no ocurre. Acompaña al cambio equivalente del lado de la API.

El verbo se corrigió en:

- `src/assets/apis/onboarding/{es,en}.yaml` — la operación de `/api/merchants/{merchantId}`. De ahí salen la referencia renderizada, los specs descargables y las colecciones Postman.
- La referencia de la API y la página **Actualizar un comercio** — tags, `<ApiReader>` y los ejemplos de cURL.
- **Autenticación** — la tabla que asocia `onboarding:update` con su operación.
- **Datos del comercio** — las filas que explican que el identificador viaja en la ruta.
- **Integraciones del sitio** — la nota sobre la URL derivada del `notifier`.

Todo en español e inglés. El changelog de Onboarding recoge el cambio bajo la fecha de hoy.

## Un cambio fuera de Onboarding

`src/components/Tag.jsx` no tenía color para `PATCH`: su mapa cubría `get`, `post`, `put` y `delete`, y cualquier otro verbo caía al color de `GET`. Este es el primer `PATCH` de la documentación, así que el badge se habría visto igual que un `GET` tanto en la referencia como en los bloques de código. Toma el ámbar que usaba `PUT`, a quien reemplaza.

## Verificación

- `npm run build` en verde. El HTML exportado de las páginas afectadas no conserva ninguna mención de `PUT`.
- Los specs descargables (YAML y JSON, ES y EN) y ambas colecciones Postman se generan con `PATCH`.
- `npm run scan:sensitive` pasa.
