### PR TITLE
docs(onboarding): expand api reference with verified request examples

### DIFF
--- a/scripts/scanSensitive.js
+++ b/scripts/scanSensitive.js
@@ -29,9 +29,12 @@ const patterns = [
 const exceptions = [
   'servicioposventa@placetopay.com',
   'Bearer test123abc123abc123abc123abc123abc123abc123abc123abc123abc',
-  '"login": "123example456token789abc012def345"',
+  '"login": "example456token789abc012def3456"',
   '"login": "aabbccdd1234567890aabbccdd123456"',
-  '"tranKey": "ABC123example456trankey+789abc012def3456ABC="'
+  // Autenticacion de Checkout, Core, Microsites y Token Requestor: un SHA-1 en base64.
+  '"tranKey": "ABC123example456trankey+789abc012def3456ABC="',
+  // Onboarding: credencial generada por el API, de 16 caracteres.
+  '"tranKey": "exampleTranKey16"'
 ].map(s => s.toLowerCase());
 
 function shouldScan(file) {

--- a/src/assets/apis/onboarding/en.yaml
+++ b/src/assets/apis/onboarding/en.yaml
@@ -502,7 +502,15 @@ components:
           example: '5411'
         size:
           type: string
-          description: Tamaño del comercio, del catálogo de tamaños.
+          description: |
+            Tamaño del comercio, del catálogo de tamaños: `XS` microempresa (menos de 10 empleados),
+            `S` pequeña empresa (menos de 50), `M` mediana empresa (menos de 250) y `L` gran empresa
+            (más de 250).
+          enum:
+            - XS
+            - S
+            - M
+            - L
           example: M
         timezone:
           type: string
@@ -558,6 +566,7 @@ components:
         paymentMethods:
           type: array
           minItems: 1
+          maxItems: 50
           description: |
             Medios de pago que el comercio acepta. Un elemento **o** modifica uno existente por su
             `id`, **o** registra uno nuevo con `code`; nunca las dos cosas.
@@ -566,6 +575,7 @@ components:
         sites:
           type: array
           minItems: 1
+          maxItems: 10
           description: Sitios de venta del comercio, con sus propias colecciones.
           items:
             $ref: '#/components/schemas/Site'
@@ -1661,8 +1671,11 @@ components:
         language:
           type: string
           maxLength: 5
-          description: Idioma del sitio, del catálogo y con la grafía exacta.
-          example: ES
+          description: |
+            Idioma del sitio, del catálogo y con la **grafía exacta**: a diferencia de `languages` en
+            la raíz, aquí la comparación distingue mayúsculas. Hoy el catálogo escribe el idioma en
+            minúscula (`es`) y la moneda en mayúscula (`COP`).
+          example: es
         email:
           type: string
           format: email
@@ -1936,7 +1949,11 @@ components:
           example: 19
         patternReference:
           type: [string, 'null']
+          pattern: '^[0-9]{0,30}$'
           maxLength: 30
+          description: |
+            Solo dígitos, hasta 30. Un valor con letras o guiones como `ORD-2026` responde `422`.
+          example: '1234567890'
 
     SiteSubscriptionValidationBlock:
       title: subscriptionValidation

--- a/src/assets/apis/onboarding/es.yaml
+++ b/src/assets/apis/onboarding/es.yaml
@@ -502,7 +502,15 @@ components:
           example: '5411'
         size:
           type: string
-          description: Tamaño del comercio, del catálogo de tamaños.
+          description: |
+            Tamaño del comercio, del catálogo de tamaños: `XS` microempresa (menos de 10 empleados),
+            `S` pequeña empresa (menos de 50), `M` mediana empresa (menos de 250) y `L` gran empresa
+            (más de 250).
+          enum:
+            - XS
+            - S
+            - M
+            - L
           example: M
         timezone:
           type: string
@@ -558,6 +566,7 @@ components:
         paymentMethods:
           type: array
           minItems: 1
+          maxItems: 50
           description: |
             Medios de pago que el comercio acepta. Un elemento **o** modifica uno existente por su
             `id`, **o** registra uno nuevo con `code`; nunca las dos cosas.
@@ -566,6 +575,7 @@ components:
         sites:
           type: array
           minItems: 1
+          maxItems: 10
           description: Sitios de venta del comercio, con sus propias colecciones.
           items:
             $ref: '#/components/schemas/Site'
@@ -1661,8 +1671,11 @@ components:
         language:
           type: string
           maxLength: 5
-          description: Idioma del sitio, del catálogo y con la grafía exacta.
-          example: ES
+          description: |
+            Idioma del sitio, del catálogo y con la **grafía exacta**: a diferencia de `languages` en
+            la raíz, aquí la comparación distingue mayúsculas. Hoy el catálogo escribe el idioma en
+            minúscula (`es`) y la moneda en mayúscula (`COP`).
+          example: es
         email:
           type: string
           format: email
@@ -1936,7 +1949,11 @@ components:
           example: 19
         patternReference:
           type: [string, 'null']
+          pattern: '^[0-9]{0,30}$'
           maxLength: 30
+          description: |
+            Solo dígitos, hasta 30. Un valor con letras o guiones como `ORD-2026` responde `422`.
+          example: '1234567890'
 
     SiteSubscriptionValidationBlock:
       title: subscriptionValidation

--- a/src/pages/en/onboarding/api/reference/merchants.mdx
+++ b/src/pages/en/onboarding/api/reference/merchants.mdx
@@ -14,6 +14,8 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   <Col>
     Valida el comercio completo y lo acepta para su registro. La respuesta llega antes de que el comercio exista: trae un `processId` con el que [consultar el resultado](/en/onboarding/process-status).
 
+    El selector de la solicitud recorre tres escenarios: el **cuerpo mínimo**, un comercio **con sus sitios y medios de pago** —donde se ve lo que un sitio obliga a enviar— y el cuerpo **con todos los campos** que la petición acepta.
+
     Las tres colecciones del cuerpo —`integrations`, `paymentMethods` y `sites`— tienen reglas propias de identidad y actualización que se explican en [Integraciones](/en/onboarding/integrations), [Medios de pago](/en/onboarding/payment-methods) y [Sitios](/en/onboarding/sites).
 
     <ApiReader
@@ -32,26 +34,286 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   </Col>
   <Col sticky>
     <CodeGroup title="Solicitud" tag="POST" label="/api/merchants">
+```bash {{ title: 'Crear comercio con datos mínimos' }}
+curl --request POST \
+  --url '{URL_BASE}/api/merchants' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme",
+    "languages": ["es"],
+    "currencies": ["COP"],
+    "document": { "type": "NIT", "number": "9001234567" },
+    "address": { "city": "Bogota", "country": "CO", "state": 11 },
+    "legalRepresentative": { "name": "Ada", "surname": "Lovelace" },
+    "control": { "reseller": 1 }
+  }'
+```
 
-    ```bash {{ title: 'cURL' }}
-    curl --request POST \
-      --url '{URL_BASE}/api/merchants' \
-      --header 'Accept: application/json' \
-      --header 'Content-Type: application/json' \
-      --header 'Authorization: Bearer {TU_TOKEN}' \
-      --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
-      --data '{
-        "name": "Comercializadora Acme S.A.S.",
-        "brand": "Acme",
-        "languages": ["es"],
-        "currencies": ["COP"],
-        "document": { "type": "NIT", "number": "9001234567" },
-        "address": { "city": "Bogota", "country": "CO", "state": 11 },
-        "legalRepresentative": { "name": "Ada", "surname": "Lovelace" },
-        "control": { "reseller": 1 }
-      }'
-    ```
+```bash {{ title: 'Crear comercio con sitios y medios de pago' }}
+curl --request POST \
+  --url '{URL_BASE}/api/merchants' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme",
+    "languages": ["es"],
+    "currencies": ["COP"],
+    "document": { "type": "NIT", "number": "9001234567" },
+    "address": { "city": "Bogota", "country": "CO", "state": 11 },
+    "legalRepresentative": { "name": "Ada", "surname": "Lovelace" },
+    "control": { "reseller": 1 },
+    "paymentMethods": [
+      {
+        "code": "CR_VS",
+        "financialEntity": 7,
+        "accountNumber": "1234567890",
+        "accountType": 2,
+        "commissionModel": "P",
+        "commissionValue": 2.5
+      }
+    ],
+    "sites": [
+      {
+        "name": "Tienda principal",
+        "displayName": "Acme",
+        "type": "INT",
+        "category": "ECOMMERCE",
+        "currency": "COP",
+        "language": "es",
+        "email": "ops@acme.example.com",
+        "integration": {
+          "allowPartial": false,
+          "checkoutVersion": "v4"
+        },
+        "control": {
+          "minAmount": 1000,
+          "maxAmount": 5000000,
+          "allowedDays": 127,
+          "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+          "filterPse": false,
+          "filterByBin": false
+        },
+        "paymentMethods": [
+          { "code": "CR_VS" }
+        ]
+      }
+    ],
+    "notification": {
+      "url": "https://acme.example.com/hooks/onboarding"
+    }
+  }'
+```
 
+```bash {{ title: 'Crear comercio con todos los campos' }}
+curl --request POST \
+  --url '{URL_BASE}/api/merchants' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme",
+    "active": true,
+    "url": "https://acme.example.com",
+    "incrementType": "IPC",
+    "mcc": "5411",
+    "size": "M",
+    "timezone": "America/Bogota",
+    "languages": ["es", "en"],
+    "currencies": ["COP", "USD"],
+    "document": {
+      "type": "NIT",
+      "number": "9001234567"
+    },
+    "address": {
+      "street": "Carrera 43A # 1-50, Torre 2",
+      "city": "Bogota",
+      "country": "CO",
+      "state": 11,
+      "phone": "6013905000",
+      "postalCode": "110111"
+    },
+    "legalRepresentative": {
+      "name": "Ada",
+      "surname": "Lovelace",
+      "documentType": "CC",
+      "document": "1020304050"
+    },
+    "billing": {
+      "contact": "Contabilidad Acme",
+      "mail": "facturacion@acme.example.com",
+      "registrationNumber": "9001234567-1",
+      "ciiu": "4791",
+      "taxType": 1,
+      "taxRegime": 1,
+      "organizationType": 1
+    },
+    "travelAgency": {
+      "dispersion": false,
+      "iata": "ABCD12"
+    },
+    "control": {
+      "reseller": 1,
+      "seller": 1,
+      "paymentFacilitator": null
+    },
+    "integrations": [
+      {
+        "type": "kount",
+        "settings": {
+          "sandbox": false,
+          "website": "ACME",
+          "merchant": "201000"
+        }
+      },
+      {
+        "type": "push_notification",
+        "settings": {
+          "enabled": true
+        }
+      }
+    ],
+    "paymentMethods": [
+      {
+        "code": "CR_VS",
+        "financialEntity": 7,
+        "accountNumber": "1234567890",
+        "accountType": 2,
+        "commissionModel": "P",
+        "commissionValue": 2.5,
+        "order": 1,
+        "creditRules": {
+          "minInstallments": 1,
+          "maxInstallments": 36
+        },
+        "settings": {
+          "merchantCode": "201000",
+          "terminalNumber": "00000001",
+          "isEcommerce": true,
+          "threeDSProvider": "placetopay"
+        }
+      }
+    ],
+    "sites": [
+      {
+        "login": "aabbccdd1234567890aabbccdd123456",
+        "name": "Tienda principal",
+        "displayName": "Acme",
+        "type": "INT",
+        "category": "ECOMMERCE",
+        "active": true,
+        "onTest": false,
+        "currency": "COP",
+        "language": "es",
+        "email": "ops@acme.example.com",
+        "customBatch": 1,
+        "expiration": "2027-01-31 23:59:59",
+        "productionDate": "2026-09-01",
+        "integration": {
+          "allowPartial": false,
+          "checkoutVersion": "v4",
+          "connectionMethod": "REDIRECT",
+          "notificationUrl": "https://acme.example.com/pay/notify",
+          "analyticsCode": "G-ABCDE12345",
+          "sourceRestriction": null,
+          "allowWallet": true,
+          "checkoutAttemptsLimit": 5,
+          "returnAdditional": false,
+          "payerFieldsType": 0
+        },
+        "control": {
+          "minAmount": 1000,
+          "maxAmount": 5000000,
+          "allowedDays": 127,
+          "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+          "filterPse": false,
+          "filterByBin": false,
+          "filterTuya": false,
+          "filterSafetypay": false,
+          "prechargeFilter": 0,
+          "allowedBankCountries": ["CO"],
+          "exceptionBinsList": ["411111"],
+          "delegatedAuthorization": null
+        },
+        "threeDS": {
+          "setting": "LOW",
+          "minAmount": 100000
+        },
+        "securityFilters": {
+          "filterLockedByTries": true,
+          "forceIPMatch": false,
+          "onlyWhitelisted": false,
+          "allowedIssuerCountries": ["CO"],
+          "allowedIPCountries": ["CO", "US"],
+          "excludeIPCountry": null,
+          "allowedCardsDay": 5,
+          "allowedCardsMonth": 20,
+          "allowedCardsYear": 60,
+          "allowedCardsByIP": 10,
+          "dayMax": 5,
+          "monthMax": 100,
+          "dayMaxAmount": 10000000,
+          "monthMaxAmount": 200000000
+        },
+        "operation": {
+          "disableTax": false,
+          "calculateTax": true,
+          "mailCustomer": true,
+          "mailMerchant": false,
+          "taxPercentage": 19,
+          "patternReference": "1234567890"
+        },
+        "subscriptionValidation": {
+          "enable": true,
+          "amount": 1000
+        },
+        "branding": {
+          "buttonColor": "#1a73e8",
+          "sidebarColor": "#0b1220"
+        },
+        "metadata": {
+          "contractRef": "AC-2026-0042",
+          "onboardingBatch": 17
+        },
+        "integrations": [
+          {
+            "type": "clicktopay_visa",
+            "settings": {
+              "enabled": true
+            }
+          }
+        ],
+        "paymentMethods": [
+          {
+            "code": "CR_VS",
+            "financialEntity": 7,
+            "accountNumber": "1234567890",
+            "accountType": 2,
+            "minAmount": 2000,
+            "maxAmount": 900000,
+            "commissionModel": "P",
+            "commissionValue": 2.5,
+            "order": 1,
+            "settings": {
+              "terminalNumber": "00000002"
+            }
+          }
+        ]
+      }
+    ],
+    "notification": {
+      "url": "https://acme.example.com/hooks/onboarding"
+    }
+  }'
+```
     </CodeGroup>
   </Col>
 </Row>
@@ -108,7 +370,15 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
 
 <Row>
   <Col>
-    Escribe solo los campos que el cuerpo nombra. El resto del comercio conserva su valor, y ningún campo es obligatorio — pero el cuerpo debe nombrar al menos uno.
+    Escribe solo los campos que el cuerpo nombra. El resto del comercio conserva su valor, y ningún campo es obligatorio — pero el cuerpo debe nombrar al menos uno: un `{}` responde `422` con la clave de error `body`, y un cuerpo que solo trae `notification` cuenta igualmente como vacío.
+
+    Dentro de las colecciones, cada elemento **o** modifica una fila existente por su identificador, **o** crea una nueva. Un sitio sin `id` es un sitio que se crea, y entonces vuelven a ser obligatorios todos sus campos: el error lo dice explícitamente, `The sites.0.displayName field is required when sites.0.id is not present.`
+
+    <Note>
+      Al actualizar, un sitio habilita un medio de pago del comercio con **`paymentMethodId`**, no con `code` — también un sitio que esta misma petición está creando, porque ese identificador señala una fila del **comercio**, que existe. Es al revés que al crear el comercio, donde `code` es la única forma posible. El detalle está en [Medios de pago del sitio](/en/onboarding/site-payment-methods).
+
+      En el `paymentMethods` de la raíz, junto al `id` viajan los **valores** —`accountNumber`, `accountType`, `commissionModel`, `commissionValue`, `order`, `creditRules`, `settings`—, pero no la **identidad**: reafirmar `code` o `financialEntity` responde `422` aunque el valor sea el que la fila ya tiene.
+    </Note>
 
     <ApiReader
       path="/api/merchants/{merchantId}"
@@ -132,17 +402,78 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   </Col>
   <Col sticky>
     <CodeGroup title="Solicitud" tag="PATCH" label="/api/merchants/{merchantId}">
+```bash {{ title: 'Cambiar datos del comercio' }}
+curl --request PATCH \
+  --url '{URL_BASE}/api/merchants/18' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme Pagos",
+    "url": "https://pagos.acme.example.com"
+  }'
+```
 
-    ```bash {{ title: 'cURL' }}
-    curl --request PATCH \
-      --url '{URL_BASE}/api/merchants/18' \
-      --header 'Accept: application/json' \
-      --header 'Content-Type: application/json' \
-      --header 'Authorization: Bearer {TU_TOKEN}' \
-      --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
-      --data '{ "name": "Comercializadora Acme S.A.S." }'
-    ```
+```bash {{ title: 'Modificar un medio de pago existente' }}
+curl --request PATCH \
+  --url '{URL_BASE}/api/merchants/18' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
+  --data '{
+    "paymentMethods": [
+      {
+        "id": 64,
+        "commissionModel": "P",
+        "commissionValue": 3.1
+      }
+    ]
+  }'
+```
 
+```bash {{ title: 'Añadir un sitio al comercio' }}
+curl --request PATCH \
+  --url '{URL_BASE}/api/merchants/18' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
+  --data '{
+    "sites": [
+      {
+        "name": "Tienda express",
+        "displayName": "Acme Express",
+        "type": "INT",
+        "category": "ECOMMERCE",
+        "currency": "COP",
+        "language": "es",
+        "email": "express@acme.example.com",
+        "integration": {
+          "allowPartial": false,
+          "checkoutVersion": "v4"
+        },
+        "control": {
+          "minAmount": 1000,
+          "maxAmount": 5000000,
+          "allowedDays": 127,
+          "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+          "filterPse": false,
+          "filterByBin": false
+        },
+        "operation": {
+          "mailCustomer": true,
+          "taxPercentage": 19
+        },
+        "paymentMethods": [
+          { "paymentMethodId": 64 }
+        ]
+      }
+    ]
+  }'
+```
     </CodeGroup>
   </Col>
 </Row>

--- a/src/pages/en/onboarding/api/reference/processes.mdx
+++ b/src/pages/en/onboarding/api/reference/processes.mdx
@@ -14,7 +14,11 @@ export const apiRefs = ['/api/processes/{processId}'];
   <Col>
     Devuelve el estado del proceso que devolvió una petición de escritura. Es la fuente de verdad del resultado, incluso cuando se registró una URL de notificación.
 
-    Deja de consultar cuando la respuesta **deje de traer el header `Retry-After`**, no cuando veas un valor concreto de `status.status`.
+    Deja de consultar cuando la respuesta **deje de traer el header `Retry-After`**, no cuando veas un valor concreto de `status.status`. El header desaparece en cuanto el proceso llega a un estado final, y eso vale igual para el éxito que para el fallo, así que sirve como única condición de parada.
+
+    <Note type="warning">
+      Un proceso fallido también responde `200`. La consulta funcionó; lo que falló es el proceso. El desenlace se lee en `status.status` —`OK` o `FAILED`—, nunca en el código HTTP.
+    </Note>
 
     <ApiReader
       path="/api/processes/{processId}"
@@ -32,14 +36,44 @@ export const apiRefs = ['/api/processes/{processId}'];
   </Col>
   <Col sticky>
     <CodeGroup title="Solicitud" tag="GET" label="/api/processes/{processId}">
+```bash {{ title: 'Consultar el proceso' }}
+curl --request GET \
+  --url '{URL_BASE}/api/processes/01kz0609xy2hd666mnx6b0jxpc' \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}'
+```
 
-    ```bash {{ title: 'cURL' }}
-    curl --request GET \
-      --url '{URL_BASE}/api/processes/01kz0609xy2hd666mnx6b0jxpc' \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Bearer {TU_TOKEN}'
-    ```
+```bash {{ title: 'Ver los headers de la respuesta' }}
+# --include imprime los headers: Retry-After solo llega mientras el proceso sigue en curso.
+curl --request GET --include \
+  --url '{URL_BASE}/api/processes/01kz0609xy2hd666mnx6b0jxpc' \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}'
 
+# HTTP/1.1 200 OK
+# Content-Type: application/json
+# Retry-After: 5
+```
+
+```bash {{ title: 'Sondear hasta que termine' }}
+PROCESS_ID='01kz0609xy2hd666mnx6b0jxpc'
+
+while :; do
+  RESPONSE=$(curl --silent --include \
+    --url "{URL_BASE}/api/processes/${PROCESS_ID}" \
+    --header 'Accept: application/json' \
+    --header 'Authorization: Bearer {TU_TOKEN}')
+
+  # Sin Retry-After el proceso terminó: bien o mal, pero terminó.
+  DELAY=$(printf '%s\n' "$RESPONSE" | tr -d '\r' | awk 'tolower($1) == "retry-after:" { print $2 }')
+  [ -z "$DELAY" ] && break
+
+  sleep "$DELAY"
+done
+
+# El desenlace está en status.status, nunca en el código HTTP.
+printf '%s\n' "$RESPONSE" | tail -1
+```
     </CodeGroup>
   </Col>
 </Row>

--- a/src/pages/en/onboarding/create-merchant.mdx
+++ b/src/pages/en/onboarding/create-merchant.mdx
@@ -36,7 +36,7 @@ El cuerpo describe el **estado completo** del comercio que quieres registrar. Lo
 
 <Properties>
   <Property name="Campos del comercio" type="varios" isRequired={true}>
-    Identidad, documento, dirección, representante legal, facturación y control comercial. Van directamente en la raíz: `name`, `brand`, `document`, `address`… Ver [Datos del comercio](/en/onboarding/merchant-data).
+    Identidad, documento, dirección, representante legal, facturación, agencia de viajes y control comercial. Van directamente en la raíz: `name`, `brand`, `document`, `address`… Ver [Datos del comercio](/en/onboarding/merchant-data).
   </Property>
   <Property name="integrations" type="array" isRequired={false}>
     Integraciones del comercio con proveedores externos. Ver [Integraciones](/en/onboarding/integrations).
@@ -87,67 +87,191 @@ Estos son todos los campos que Onboarding exige para registrar un comercio. Todo
 
 ## Cuerpo completo {{ id: 'full-body' }}
 
-Un registro real suele incluir también las colecciones. Este ejemplo muestra la forma general; el detalle de cada colección está en su propia página.
+Este es el cuerpo con **todos los campos** que la petición acepta. Salvo el mínimo de arriba, cada uno puede omitirse: lo que no envías queda con el valor que Onboarding tenga por defecto.
 
-<Row>
-  <Col>
-    Los campos del comercio y las colecciones conviven en el mismo nivel del cuerpo.
+Los campos del comercio y las colecciones conviven en el mismo nivel. Las colecciones son independientes entre sí —puedes enviar solo `sites`, solo `paymentMethods`, ambas o ninguna— y todo lo que envías se registra dentro de la misma operación, de modo que un comercio con sus sitios y sus medios de pago se crea con **una sola petición**.
 
-    Las colecciones son independientes entre sí: puedes enviar solo `sites`, solo `paymentMethods`, ambas o ninguna. Cada elemento que envías se registra dentro de la misma operación, de modo que un comercio con sus sitios y sus medios de pago se crea con **una sola petición**.
+| Colección | Tope | Identidad del elemento |
+|---|---|---|
+| `integrations` | 16 elementos | Un elemento por `type`; repetirlo responde `422` |
+| `paymentMethods` | 50 elementos | El `code` del medio de pago |
+| `sites` | 10 elementos | El `login`, si lo envías; si no, se genera |
+| `sites[].integrations` | 16 elementos | Independientes de las del comercio: el mismo `type` puede estar en ambas |
+| `sites[].paymentMethods` | 50 elementos | Un `code` que la colección `paymentMethods` de este mismo cuerpo declara |
 
-    El bloque `notification` es opcional y se explica más abajo.
-  </Col>
-  <Col sticky>
-    <CodeGroup title="Cuerpo completo">
+<CodeGroup title="Cuerpo completo">
 
-    ```json {{ title: 'merchant.json' }}
+```json {{ title: 'merchant.json' }}
+{
+  "name": "Comercializadora Acme S.A.S.",
+  "brand": "Acme",
+  "active": true,
+  "url": "https://acme.example.com",
+  "incrementType": "IPC",
+  "mcc": "5411",
+  "size": "M",
+  "timezone": "America/Bogota",
+  "languages": ["es", "en"],
+  "currencies": ["COP", "USD"],
+  "document": {
+    "type": "NIT",
+    "number": "9001234567"
+  },
+  "address": {
+    "street": "Carrera 43A # 1-50, Torre 2",
+    "city": "Bogota",
+    "country": "CO",
+    "state": 11,
+    "phone": "6013905000",
+    "postalCode": "110111"
+  },
+  "legalRepresentative": {
+    "name": "Ada",
+    "surname": "Lovelace",
+    "documentType": "CC",
+    "document": "1020304050"
+  },
+  "billing": {
+    "contact": "Contabilidad Acme",
+    "mail": "facturacion@acme.example.com",
+    "registrationNumber": "9001234567-1",
+    "ciiu": "4791",
+    "taxType": 1,
+    "taxRegime": 1,
+    "organizationType": 1
+  },
+  "travelAgency": {
+    "dispersion": false,
+    "iata": "ABCD12"
+  },
+  "control": {
+    "reseller": 1,
+    "seller": 1,
+    "paymentFacilitator": null
+  },
+  "integrations": [
     {
-      "name": "Comercializadora Acme S.A.S.",
-      "brand": "Acme",
+      "type": "kount",
+      "settings": {
+        "sandbox": false,
+        "website": "ACME",
+        "merchant": "201000"
+      }
+    },
+    {
+      "type": "push_notification",
+      "settings": {
+        "enabled": true
+      }
+    }
+  ],
+  "paymentMethods": [
+    {
+      "code": "CR_VS",
+      "financialEntity": 7,
+      "accountNumber": "1234567890",
+      "accountType": 2,
+      "commissionModel": "P",
+      "commissionValue": 2.5,
+      "order": 1,
+      "creditRules": {
+        "minInstallments": 1,
+        "maxInstallments": 36
+      },
+      "settings": {
+        "merchantCode": "201000",
+        "terminalNumber": "00000001",
+        "isEcommerce": true,
+        "threeDSProvider": "placetopay"
+      }
+    }
+  ],
+  "sites": [
+    {
+      "login": "aabbccdd1234567890aabbccdd123456",
+      "name": "Tienda principal",
+      "displayName": "Acme",
+      "type": "INT",
+      "category": "ECOMMERCE",
       "active": true,
-      "url": "https://acme.example.com",
-      "mcc": "5411",
-      "size": "M",
-      "timezone": "America/Bogota",
-      "languages": ["es", "en"],
-      "currencies": ["COP", "USD"],
-      "document": {
-        "type": "NIT",
-        "number": "9001234567"
-      },
-      "address": {
-        "street": "Carrera 43A # 1-50, Torre 2",
-        "city": "Bogota",
-        "country": "CO",
-        "state": 11,
-        "phone": "6013905000",
-        "postalCode": "110111"
-      },
-      "legalRepresentative": {
-        "name": "Ada",
-        "surname": "Lovelace",
-        "documentType": "CC",
-        "document": "1020304050"
-      },
-      "billing": {
-        "contact": "Contabilidad Acme",
-        "mail": "facturacion@acme.example.com",
-        "ciiu": "4791",
-        "taxType": 1,
-        "taxRegime": 1,
-        "organizationType": 1
+      "onTest": false,
+      "currency": "COP",
+      "language": "es",
+      "email": "ops@acme.example.com",
+      "customBatch": 1,
+      "expiration": "2027-01-31 23:59:59",
+      "productionDate": "2026-09-01",
+      "integration": {
+        "allowPartial": false,
+        "checkoutVersion": "v4",
+        "connectionMethod": "REDIRECT",
+        "notificationUrl": "https://acme.example.com/pay/notify",
+        "analyticsCode": "G-ABCDE12345",
+        "sourceRestriction": null,
+        "allowWallet": true,
+        "checkoutAttemptsLimit": 5,
+        "returnAdditional": false,
+        "payerFieldsType": 0
       },
       "control": {
-        "reseller": 1,
-        "seller": 1
+        "minAmount": 1000,
+        "maxAmount": 5000000,
+        "allowedDays": 127,
+        "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+        "filterPse": false,
+        "filterByBin": false,
+        "filterTuya": false,
+        "filterSafetypay": false,
+        "prechargeFilter": 0,
+        "allowedBankCountries": ["CO"],
+        "exceptionBinsList": ["411111"],
+        "delegatedAuthorization": null
+      },
+      "threeDS": {
+        "setting": "LOW",
+        "minAmount": 100000
+      },
+      "securityFilters": {
+        "filterLockedByTries": true,
+        "forceIPMatch": false,
+        "onlyWhitelisted": false,
+        "allowedIssuerCountries": ["CO"],
+        "allowedIPCountries": ["CO", "US"],
+        "excludeIPCountry": null,
+        "allowedCardsDay": 5,
+        "allowedCardsMonth": 20,
+        "allowedCardsYear": 60,
+        "allowedCardsByIP": 10,
+        "dayMax": 5,
+        "monthMax": 100,
+        "dayMaxAmount": 10000000,
+        "monthMaxAmount": 200000000
+      },
+      "operation": {
+        "disableTax": false,
+        "calculateTax": true,
+        "mailCustomer": true,
+        "mailMerchant": false,
+        "taxPercentage": 19,
+        "patternReference": "1234567890"
+      },
+      "subscriptionValidation": {
+        "enable": true,
+        "amount": 1000
+      },
+      "branding": {
+        "buttonColor": "#1a73e8",
+        "sidebarColor": "#0b1220"
+      },
+      "metadata": {
+        "contractRef": "AC-2026-0042",
+        "onboardingBatch": 17
       },
       "integrations": [
         {
-          "type": "kount",
+          "type": "clicktopay_visa",
           "settings": {
-            "sandbox": false,
-            "website": "ACME",
-            "merchant": "201000"
+            "enabled": true
           }
         }
       ],
@@ -157,19 +281,57 @@ Un registro real suele incluir también las colecciones. Este ejemplo muestra la
           "financialEntity": 7,
           "accountNumber": "1234567890",
           "accountType": 2,
+          "minAmount": 2000,
+          "maxAmount": 900000,
           "commissionModel": "P",
-          "commissionValue": 2.5
+          "commissionValue": 2.5,
+          "order": 1,
+          "settings": {
+            "terminalNumber": "00000002"
+          }
         }
-      ],
-      "notification": {
-        "url": "https://acme.example.com/hooks/onboarding"
-      }
+      ]
     }
-    ```
+  ],
+  "notification": {
+    "url": "https://acme.example.com/hooks/onboarding"
+  }
+}
+```
 
-    </CodeGroup>
-  </Col>
-</Row>
+</CodeGroup>
+
+<Note>
+  Los valores de catálogo —`mcc`, `size`, `timezone`, `state`, `taxType`, `taxRegime`, `organizationType`, `reseller`, `seller`, `paymentFacilitator`, `code`, `financialEntity`, `accountType`— salen de los catálogos de Placetopay y **dependen del ambiente**. Los del ejemplo son ilustrativos: pide los tuyos junto con las credenciales, porque un identificador válido en un ambiente no tiene por qué serlo en otro. Además, `reseller` y `seller` deben estar habilitados, no solo existir.
+</Note>
+
+### Un sitio obliga a mucho más que un comercio {{ id: 'site-required-fields' }}
+
+`sites` es opcional, pero **en cuanto envías un sitio casi todo lo suyo pasa a ser obligatorio**: `name`, `displayName`, `type`, `category`, `currency`, `language`, `email` y los bloques `integration` y `control` completos —con sus propios `allowPartial`, `checkoutVersion`, `minAmount`, `maxAmount`, `allowedDays`, `allowedHours`, `filterPse` y `filterByBin`—. El resto de bloques (`threeDS`, `securityFilters`, `operation`, `subscriptionValidation`, `branding`, `metadata`) sigue siendo opcional. El detalle está en [Sitios](/en/onboarding/sites).
+
+Tres formatos que suelen sorprender:
+
+- **El sitio distingue mayúsculas donde la raíz no.** `languages` y `currencies` de la raíz aceptan cualquier grafía, pero `sites[].language` y `sites[].currency` exigen la del catálogo, que hoy escribe el idioma en minúscula (`es`) y la moneda en mayúscula (`COP`). Un `"language": "ES"` dentro de un sitio responde `422` — y el mensaje del error te dice la grafía que espera.
+- **`allowedHours` son 42 caracteres hexadecimales exactos.** Una cadena más corta no produce un error: produce un horario equivocado.
+- **`sites[].paymentMethods[].code` solo puede nombrar un medio de pago que este mismo cuerpo declaró** en el `paymentMethods` de la raíz. Al crear no hay nada preexistente a lo que apuntar, porque el comercio todavía no existe.
+- **Dentro del sitio basta el `code`.** Los datos de cuenta y comisión son obligatorios en el `paymentMethods` de la raíz, pero opcionales dentro de un sitio: lo que no nombras se hereda del medio de pago del comercio. Envía solo lo que deba diferir.
+
+### Lo que el ejemplo deja fuera {{ id: 'omitted-credentials' }}
+
+Un sitio admite además tres credenciales —`login`, `tranKey` y `md5Hash`, de hasta 32 caracteres cada una— que aquí se omiten a propósito. Si no las envías, Onboarding las genera y te las devuelve en el resultado del proceso, que es la forma recomendada de obtenerlas; las que genera son de 16 caracteres. El ejemplo solo conserva `login` para mostrar dónde va.
+
+## Campos que la petición rechaza {{ id: 'rejected-fields' }}
+
+Estos campos no son ignorados: si viajan en el cuerpo de una creación, la respuesta es `422` nombrándolos. Casi todos son identificadores que solo tienen sentido cuando el comercio ya existe, así que aparecen al reenviar como petición un cuerpo copiado de una respuesta.
+
+| Campo | Por qué |
+|---|---|
+| `id`, `merchantId` en la raíz | El identificador del comercio viaja en la URL, no en el cuerpo — y en una creación todavía no existe |
+| `integrations[].id` | Una integración se identifica por su `type` |
+| `paymentMethods[].id` | Solo existe al [actualizar](/en/onboarding/update-merchant); al crear, la identidad es el `code` |
+| `sites[].id`, `sites[].customerId` | El sitio se está creando |
+| `sites[].integrations[].siteId` | El sitio que la lleva es el que la contiene |
+| `sites[].paymentMethods[].id`, `.paymentMethodId`, `.siteId` | Al crear, la única forma de nombrar un medio de pago es su `code` |
 
 ## La URL de notificación {{ id: 'notification-url' }}
 

--- a/src/pages/en/onboarding/site-payment-methods.mdx
+++ b/src/pages/en/onboarding/site-payment-methods.mdx
@@ -27,6 +27,8 @@ Cada elemento indica de qué fila habla de **una sola de estas tres maneras**. E
   `siteId` responde `422` siempre: el sitio es el elemento que contiene la colección, no un campo suyo.
 </Note>
 
+En una frase: **`paymentMethodId` habilita, `id` modifica lo ya habilitado.** De ahí sale el caso que más confunde — un sitio que **se está creando** dentro de una actualización sí puede usar `paymentMethodId`, porque ese identificador señala una fila del **comercio**, que existe. Lo que no puede es usar `id`, porque no tiene todavía ninguna habilitación propia que modificar. El error lo dice tal cual: `A site being created carries no payment method to address.`
+
 Los dos identificadores los publica el resultado de un proceso: `paymentMethodId` sale de `result.paymentMethods[].id` y el `id` de la habilitación, de `result.sites[].paymentMethods[].id`. Consérvalos, porque [no hay forma de consultarlos después](/en/onboarding/payment-methods#where-the-id-comes-from).
 
 ### `id` — modificar una habilitación existente
@@ -175,7 +177,8 @@ La marca se escribe solo cuando algo cambió realmente, y nunca en un sitio que 
 | Un `paymentMethodId` que no pertenece al comercio | `422` sobre `paymentMethodId` |
 | Un `paymentMethodId` que el sitio ya tiene habilitado | `422` sobre `paymentMethodId` |
 | Un `code` que la raíz del cuerpo no declara, o declara dos veces | `422` sobre `code` |
-| `id` o `paymentMethodId` en una creación, o en un sitio que se está creando | `422` |
+| `id` o `paymentMethodId` en una creación (`POST`) | `422` |
+| `id` en un sitio que se está creando dentro de un `PATCH` | `422` |
 | Dos elementos del mismo sitio que señalan el mismo medio de pago | `422` |
 
 <Note>

--- a/src/pages/en/onboarding/sites.mdx
+++ b/src/pages/en/onboarding/sites.mdx
@@ -19,7 +19,7 @@ Lo que determina si un elemento crea un sitio nuevo o modifica uno existente es 
 | **Con `id`** | Modifica ese sitio. Solo cambia lo que nombras; el resto se conserva |
 
 <Note>
-  `sites[].id` es la **única excepción** a la regla de que los identificadores no viajan en el cuerpo. Es necesaria porque un sitio no tiene otro campo estable con el que referenciarlo: su nombre de acceso puede cambiarlo la misma petición.
+  La regla es más precisa de lo que parece: el identificador del **comercio** nunca viaja en el cuerpo —va siempre en la URL, y `id`, `merchantId` o `customerId` responden `422`—, pero los de sus **recursos hijos** sí, y son justamente la forma de direccionar filas existentes: `sites[].id`, `paymentMethods[].id`, y en `sites[].paymentMethods[]` tanto `id` como `paymentMethodId`.
 </Note>
 
 En una creación (`POST`), enviar `sites[].id` responde `422`, porque no hay sitios previos que modificar. En una actualización, el `id` debe pertenecer al comercio de la URL. El campo `customerId` responde `422` siempre: el comercio viaja en la URL.
@@ -92,7 +92,7 @@ Como el `login` no distingue mayúsculas, `ACME` y `acme` son el mismo identific
           "category": "ECOMMERCE",
           "email": "ops@acme.example.com",
           "currency": "COP",
-          "language": "ES",
+          "language": "es",
           "onTest": true,
           "integration": {
             "allowPartial": false,
@@ -392,14 +392,16 @@ No hay forma de volver a leerlas: ningún endpoint las devuelve. Lo que sí pued
           {
             "id": 214,
             "login": "aabbccdd1234567890aabbccdd123456",
-            "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+            "tranKey": "exampleTranKey16",
+            "md5Hash": "exampleMd5Hash16",
             "active": true,
             "action": "created"
           },
           {
             "id": 209,
-            "login": "123example456token789abc012def345",
+            "login": "example456token789abc012def3456",
             "tranKey": null,
+            "md5Hash": null,
             "active": true,
             "action": "updated"
           }

--- a/src/pages/onboarding/api/reference/merchants.mdx
+++ b/src/pages/onboarding/api/reference/merchants.mdx
@@ -12,6 +12,8 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   <Col>
     Valida el comercio completo y lo acepta para su registro. La respuesta llega antes de que el comercio exista: trae un `processId` con el que [consultar el resultado](/onboarding/process-status).
 
+    El selector de la solicitud recorre tres escenarios: el **cuerpo mínimo**, un comercio **con sus sitios y medios de pago** —donde se ve lo que un sitio obliga a enviar— y el cuerpo **con todos los campos** que la petición acepta.
+
     Las tres colecciones del cuerpo —`integrations`, `paymentMethods` y `sites`— tienen reglas propias de identidad y actualización que se explican en [Integraciones](/onboarding/integrations), [Medios de pago](/onboarding/payment-methods) y [Sitios](/onboarding/sites).
 
     <ApiReader
@@ -30,26 +32,286 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   </Col>
   <Col sticky>
     <CodeGroup title="Solicitud" tag="POST" label="/api/merchants">
+```bash {{ title: 'Crear comercio con datos mínimos' }}
+curl --request POST \
+  --url '{URL_BASE}/api/merchants' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme",
+    "languages": ["es"],
+    "currencies": ["COP"],
+    "document": { "type": "NIT", "number": "9001234567" },
+    "address": { "city": "Bogota", "country": "CO", "state": 11 },
+    "legalRepresentative": { "name": "Ada", "surname": "Lovelace" },
+    "control": { "reseller": 1 }
+  }'
+```
 
-    ```bash {{ title: 'cURL' }}
-    curl --request POST \
-      --url '{URL_BASE}/api/merchants' \
-      --header 'Accept: application/json' \
-      --header 'Content-Type: application/json' \
-      --header 'Authorization: Bearer {TU_TOKEN}' \
-      --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
-      --data '{
-        "name": "Comercializadora Acme S.A.S.",
-        "brand": "Acme",
-        "languages": ["es"],
-        "currencies": ["COP"],
-        "document": { "type": "NIT", "number": "9001234567" },
-        "address": { "city": "Bogota", "country": "CO", "state": 11 },
-        "legalRepresentative": { "name": "Ada", "surname": "Lovelace" },
-        "control": { "reseller": 1 }
-      }'
-    ```
+```bash {{ title: 'Crear comercio con sitios y medios de pago' }}
+curl --request POST \
+  --url '{URL_BASE}/api/merchants' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme",
+    "languages": ["es"],
+    "currencies": ["COP"],
+    "document": { "type": "NIT", "number": "9001234567" },
+    "address": { "city": "Bogota", "country": "CO", "state": 11 },
+    "legalRepresentative": { "name": "Ada", "surname": "Lovelace" },
+    "control": { "reseller": 1 },
+    "paymentMethods": [
+      {
+        "code": "CR_VS",
+        "financialEntity": 7,
+        "accountNumber": "1234567890",
+        "accountType": 2,
+        "commissionModel": "P",
+        "commissionValue": 2.5
+      }
+    ],
+    "sites": [
+      {
+        "name": "Tienda principal",
+        "displayName": "Acme",
+        "type": "INT",
+        "category": "ECOMMERCE",
+        "currency": "COP",
+        "language": "es",
+        "email": "ops@acme.example.com",
+        "integration": {
+          "allowPartial": false,
+          "checkoutVersion": "v4"
+        },
+        "control": {
+          "minAmount": 1000,
+          "maxAmount": 5000000,
+          "allowedDays": 127,
+          "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+          "filterPse": false,
+          "filterByBin": false
+        },
+        "paymentMethods": [
+          { "code": "CR_VS" }
+        ]
+      }
+    ],
+    "notification": {
+      "url": "https://acme.example.com/hooks/onboarding"
+    }
+  }'
+```
 
+```bash {{ title: 'Crear comercio con todos los campos' }}
+curl --request POST \
+  --url '{URL_BASE}/api/merchants' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 8f1c2d3e4a5b6c7d8e9f0a1b' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme",
+    "active": true,
+    "url": "https://acme.example.com",
+    "incrementType": "IPC",
+    "mcc": "5411",
+    "size": "M",
+    "timezone": "America/Bogota",
+    "languages": ["es", "en"],
+    "currencies": ["COP", "USD"],
+    "document": {
+      "type": "NIT",
+      "number": "9001234567"
+    },
+    "address": {
+      "street": "Carrera 43A # 1-50, Torre 2",
+      "city": "Bogota",
+      "country": "CO",
+      "state": 11,
+      "phone": "6013905000",
+      "postalCode": "110111"
+    },
+    "legalRepresentative": {
+      "name": "Ada",
+      "surname": "Lovelace",
+      "documentType": "CC",
+      "document": "1020304050"
+    },
+    "billing": {
+      "contact": "Contabilidad Acme",
+      "mail": "facturacion@acme.example.com",
+      "registrationNumber": "9001234567-1",
+      "ciiu": "4791",
+      "taxType": 1,
+      "taxRegime": 1,
+      "organizationType": 1
+    },
+    "travelAgency": {
+      "dispersion": false,
+      "iata": "ABCD12"
+    },
+    "control": {
+      "reseller": 1,
+      "seller": 1,
+      "paymentFacilitator": null
+    },
+    "integrations": [
+      {
+        "type": "kount",
+        "settings": {
+          "sandbox": false,
+          "website": "ACME",
+          "merchant": "201000"
+        }
+      },
+      {
+        "type": "push_notification",
+        "settings": {
+          "enabled": true
+        }
+      }
+    ],
+    "paymentMethods": [
+      {
+        "code": "CR_VS",
+        "financialEntity": 7,
+        "accountNumber": "1234567890",
+        "accountType": 2,
+        "commissionModel": "P",
+        "commissionValue": 2.5,
+        "order": 1,
+        "creditRules": {
+          "minInstallments": 1,
+          "maxInstallments": 36
+        },
+        "settings": {
+          "merchantCode": "201000",
+          "terminalNumber": "00000001",
+          "isEcommerce": true,
+          "threeDSProvider": "placetopay"
+        }
+      }
+    ],
+    "sites": [
+      {
+        "login": "aabbccdd1234567890aabbccdd123456",
+        "name": "Tienda principal",
+        "displayName": "Acme",
+        "type": "INT",
+        "category": "ECOMMERCE",
+        "active": true,
+        "onTest": false,
+        "currency": "COP",
+        "language": "es",
+        "email": "ops@acme.example.com",
+        "customBatch": 1,
+        "expiration": "2027-01-31 23:59:59",
+        "productionDate": "2026-09-01",
+        "integration": {
+          "allowPartial": false,
+          "checkoutVersion": "v4",
+          "connectionMethod": "REDIRECT",
+          "notificationUrl": "https://acme.example.com/pay/notify",
+          "analyticsCode": "G-ABCDE12345",
+          "sourceRestriction": null,
+          "allowWallet": true,
+          "checkoutAttemptsLimit": 5,
+          "returnAdditional": false,
+          "payerFieldsType": 0
+        },
+        "control": {
+          "minAmount": 1000,
+          "maxAmount": 5000000,
+          "allowedDays": 127,
+          "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+          "filterPse": false,
+          "filterByBin": false,
+          "filterTuya": false,
+          "filterSafetypay": false,
+          "prechargeFilter": 0,
+          "allowedBankCountries": ["CO"],
+          "exceptionBinsList": ["411111"],
+          "delegatedAuthorization": null
+        },
+        "threeDS": {
+          "setting": "LOW",
+          "minAmount": 100000
+        },
+        "securityFilters": {
+          "filterLockedByTries": true,
+          "forceIPMatch": false,
+          "onlyWhitelisted": false,
+          "allowedIssuerCountries": ["CO"],
+          "allowedIPCountries": ["CO", "US"],
+          "excludeIPCountry": null,
+          "allowedCardsDay": 5,
+          "allowedCardsMonth": 20,
+          "allowedCardsYear": 60,
+          "allowedCardsByIP": 10,
+          "dayMax": 5,
+          "monthMax": 100,
+          "dayMaxAmount": 10000000,
+          "monthMaxAmount": 200000000
+        },
+        "operation": {
+          "disableTax": false,
+          "calculateTax": true,
+          "mailCustomer": true,
+          "mailMerchant": false,
+          "taxPercentage": 19,
+          "patternReference": "1234567890"
+        },
+        "subscriptionValidation": {
+          "enable": true,
+          "amount": 1000
+        },
+        "branding": {
+          "buttonColor": "#1a73e8",
+          "sidebarColor": "#0b1220"
+        },
+        "metadata": {
+          "contractRef": "AC-2026-0042",
+          "onboardingBatch": 17
+        },
+        "integrations": [
+          {
+            "type": "clicktopay_visa",
+            "settings": {
+              "enabled": true
+            }
+          }
+        ],
+        "paymentMethods": [
+          {
+            "code": "CR_VS",
+            "financialEntity": 7,
+            "accountNumber": "1234567890",
+            "accountType": 2,
+            "minAmount": 2000,
+            "maxAmount": 900000,
+            "commissionModel": "P",
+            "commissionValue": 2.5,
+            "order": 1,
+            "settings": {
+              "terminalNumber": "00000002"
+            }
+          }
+        ]
+      }
+    ],
+    "notification": {
+      "url": "https://acme.example.com/hooks/onboarding"
+    }
+  }'
+```
     </CodeGroup>
   </Col>
 </Row>
@@ -106,7 +368,15 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
 
 <Row>
   <Col>
-    Escribe solo los campos que el cuerpo nombra. El resto del comercio conserva su valor, y ningún campo es obligatorio — pero el cuerpo debe nombrar al menos uno.
+    Escribe solo los campos que el cuerpo nombra. El resto del comercio conserva su valor, y ningún campo es obligatorio — pero el cuerpo debe nombrar al menos uno: un `{}` responde `422` con la clave de error `body`, y un cuerpo que solo trae `notification` cuenta igualmente como vacío.
+
+    Dentro de las colecciones, cada elemento **o** modifica una fila existente por su identificador, **o** crea una nueva. Un sitio sin `id` es un sitio que se crea, y entonces vuelven a ser obligatorios todos sus campos: el error lo dice explícitamente, `The sites.0.displayName field is required when sites.0.id is not present.`
+
+    <Note>
+      Al actualizar, un sitio habilita un medio de pago del comercio con **`paymentMethodId`**, no con `code` — también un sitio que esta misma petición está creando, porque ese identificador señala una fila del **comercio**, que existe. Es al revés que al crear el comercio, donde `code` es la única forma posible. El detalle está en [Medios de pago del sitio](/onboarding/site-payment-methods).
+
+      En el `paymentMethods` de la raíz, junto al `id` viajan los **valores** —`accountNumber`, `accountType`, `commissionModel`, `commissionValue`, `order`, `creditRules`, `settings`—, pero no la **identidad**: reafirmar `code` o `financialEntity` responde `422` aunque el valor sea el que la fila ya tiene.
+    </Note>
 
     <ApiReader
       path="/api/merchants/{merchantId}"
@@ -130,17 +400,78 @@ export const apiRefs = ['/api/merchants', '/api/merchants/{merchantId}'];
   </Col>
   <Col sticky>
     <CodeGroup title="Solicitud" tag="PATCH" label="/api/merchants/{merchantId}">
+```bash {{ title: 'Cambiar datos del comercio' }}
+curl --request PATCH \
+  --url '{URL_BASE}/api/merchants/18' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
+  --data '{
+    "name": "Comercializadora Acme S.A.S.",
+    "brand": "Acme Pagos",
+    "url": "https://pagos.acme.example.com"
+  }'
+```
 
-    ```bash {{ title: 'cURL' }}
-    curl --request PATCH \
-      --url '{URL_BASE}/api/merchants/18' \
-      --header 'Accept: application/json' \
-      --header 'Content-Type: application/json' \
-      --header 'Authorization: Bearer {TU_TOKEN}' \
-      --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
-      --data '{ "name": "Comercializadora Acme S.A.S." }'
-    ```
+```bash {{ title: 'Modificar un medio de pago existente' }}
+curl --request PATCH \
+  --url '{URL_BASE}/api/merchants/18' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
+  --data '{
+    "paymentMethods": [
+      {
+        "id": 64,
+        "commissionModel": "P",
+        "commissionValue": 3.1
+      }
+    ]
+  }'
+```
 
+```bash {{ title: 'Añadir un sitio al comercio' }}
+curl --request PATCH \
+  --url '{URL_BASE}/api/merchants/18' \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}' \
+  --header 'Idempotency-Key: 4b7e1a9c2d3f5e6a8b0c1d2e' \
+  --data '{
+    "sites": [
+      {
+        "name": "Tienda express",
+        "displayName": "Acme Express",
+        "type": "INT",
+        "category": "ECOMMERCE",
+        "currency": "COP",
+        "language": "es",
+        "email": "express@acme.example.com",
+        "integration": {
+          "allowPartial": false,
+          "checkoutVersion": "v4"
+        },
+        "control": {
+          "minAmount": 1000,
+          "maxAmount": 5000000,
+          "allowedDays": 127,
+          "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+          "filterPse": false,
+          "filterByBin": false
+        },
+        "operation": {
+          "mailCustomer": true,
+          "taxPercentage": 19
+        },
+        "paymentMethods": [
+          { "paymentMethodId": 64 }
+        ]
+      }
+    ]
+  }'
+```
     </CodeGroup>
   </Col>
 </Row>

--- a/src/pages/onboarding/api/reference/processes.mdx
+++ b/src/pages/onboarding/api/reference/processes.mdx
@@ -12,7 +12,11 @@ export const apiRefs = ['/api/processes/{processId}'];
   <Col>
     Devuelve el estado del proceso que devolvió una petición de escritura. Es la fuente de verdad del resultado, incluso cuando se registró una URL de notificación.
 
-    Deja de consultar cuando la respuesta **deje de traer el header `Retry-After`**, no cuando veas un valor concreto de `status.status`.
+    Deja de consultar cuando la respuesta **deje de traer el header `Retry-After`**, no cuando veas un valor concreto de `status.status`. El header desaparece en cuanto el proceso llega a un estado final, y eso vale igual para el éxito que para el fallo, así que sirve como única condición de parada.
+
+    <Note type="warning">
+      Un proceso fallido también responde `200`. La consulta funcionó; lo que falló es el proceso. El desenlace se lee en `status.status` —`OK` o `FAILED`—, nunca en el código HTTP.
+    </Note>
 
     <ApiReader
       path="/api/processes/{processId}"
@@ -30,14 +34,44 @@ export const apiRefs = ['/api/processes/{processId}'];
   </Col>
   <Col sticky>
     <CodeGroup title="Solicitud" tag="GET" label="/api/processes/{processId}">
+```bash {{ title: 'Consultar el proceso' }}
+curl --request GET \
+  --url '{URL_BASE}/api/processes/01kz0609xy2hd666mnx6b0jxpc' \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}'
+```
 
-    ```bash {{ title: 'cURL' }}
-    curl --request GET \
-      --url '{URL_BASE}/api/processes/01kz0609xy2hd666mnx6b0jxpc' \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Bearer {TU_TOKEN}'
-    ```
+```bash {{ title: 'Ver los headers de la respuesta' }}
+# --include imprime los headers: Retry-After solo llega mientras el proceso sigue en curso.
+curl --request GET --include \
+  --url '{URL_BASE}/api/processes/01kz0609xy2hd666mnx6b0jxpc' \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Bearer {TU_TOKEN}'
 
+# HTTP/1.1 200 OK
+# Content-Type: application/json
+# Retry-After: 5
+```
+
+```bash {{ title: 'Sondear hasta que termine' }}
+PROCESS_ID='01kz0609xy2hd666mnx6b0jxpc'
+
+while :; do
+  RESPONSE=$(curl --silent --include \
+    --url "{URL_BASE}/api/processes/${PROCESS_ID}" \
+    --header 'Accept: application/json' \
+    --header 'Authorization: Bearer {TU_TOKEN}')
+
+  # Sin Retry-After el proceso terminó: bien o mal, pero terminó.
+  DELAY=$(printf '%s\n' "$RESPONSE" | tr -d '\r' | awk 'tolower($1) == "retry-after:" { print $2 }')
+  [ -z "$DELAY" ] && break
+
+  sleep "$DELAY"
+done
+
+# El desenlace está en status.status, nunca en el código HTTP.
+printf '%s\n' "$RESPONSE" | tail -1
+```
     </CodeGroup>
   </Col>
 </Row>

--- a/src/pages/onboarding/create-merchant.mdx
+++ b/src/pages/onboarding/create-merchant.mdx
@@ -34,7 +34,7 @@ El cuerpo describe el **estado completo** del comercio que quieres registrar. Lo
 
 <Properties>
   <Property name="Campos del comercio" type="varios" isRequired={true}>
-    Identidad, documento, dirección, representante legal, facturación y control comercial. Van directamente en la raíz: `name`, `brand`, `document`, `address`… Ver [Datos del comercio](/onboarding/merchant-data).
+    Identidad, documento, dirección, representante legal, facturación, agencia de viajes y control comercial. Van directamente en la raíz: `name`, `brand`, `document`, `address`… Ver [Datos del comercio](/onboarding/merchant-data).
   </Property>
   <Property name="integrations" type="array" isRequired={false}>
     Integraciones del comercio con proveedores externos. Ver [Integraciones](/onboarding/integrations).
@@ -85,67 +85,191 @@ Estos son todos los campos que Onboarding exige para registrar un comercio. Todo
 
 ## Cuerpo completo {{ id: 'full-body' }}
 
-Un registro real suele incluir también las colecciones. Este ejemplo muestra la forma general; el detalle de cada colección está en su propia página.
+Este es el cuerpo con **todos los campos** que la petición acepta. Salvo el mínimo de arriba, cada uno puede omitirse: lo que no envías queda con el valor que Onboarding tenga por defecto.
 
-<Row>
-  <Col>
-    Los campos del comercio y las colecciones conviven en el mismo nivel del cuerpo.
+Los campos del comercio y las colecciones conviven en el mismo nivel. Las colecciones son independientes entre sí —puedes enviar solo `sites`, solo `paymentMethods`, ambas o ninguna— y todo lo que envías se registra dentro de la misma operación, de modo que un comercio con sus sitios y sus medios de pago se crea con **una sola petición**.
 
-    Las colecciones son independientes entre sí: puedes enviar solo `sites`, solo `paymentMethods`, ambas o ninguna. Cada elemento que envías se registra dentro de la misma operación, de modo que un comercio con sus sitios y sus medios de pago se crea con **una sola petición**.
+| Colección | Tope | Identidad del elemento |
+|---|---|---|
+| `integrations` | 16 elementos | Un elemento por `type`; repetirlo responde `422` |
+| `paymentMethods` | 50 elementos | El `code` del medio de pago |
+| `sites` | 10 elementos | El `login`, si lo envías; si no, se genera |
+| `sites[].integrations` | 16 elementos | Independientes de las del comercio: el mismo `type` puede estar en ambas |
+| `sites[].paymentMethods` | 50 elementos | Un `code` que la colección `paymentMethods` de este mismo cuerpo declara |
 
-    El bloque `notification` es opcional y se explica más abajo.
-  </Col>
-  <Col sticky>
-    <CodeGroup title="Cuerpo completo">
+<CodeGroup title="Cuerpo completo">
 
-    ```json {{ title: 'merchant.json' }}
+```json {{ title: 'merchant.json' }}
+{
+  "name": "Comercializadora Acme S.A.S.",
+  "brand": "Acme",
+  "active": true,
+  "url": "https://acme.example.com",
+  "incrementType": "IPC",
+  "mcc": "5411",
+  "size": "M",
+  "timezone": "America/Bogota",
+  "languages": ["es", "en"],
+  "currencies": ["COP", "USD"],
+  "document": {
+    "type": "NIT",
+    "number": "9001234567"
+  },
+  "address": {
+    "street": "Carrera 43A # 1-50, Torre 2",
+    "city": "Bogota",
+    "country": "CO",
+    "state": 11,
+    "phone": "6013905000",
+    "postalCode": "110111"
+  },
+  "legalRepresentative": {
+    "name": "Ada",
+    "surname": "Lovelace",
+    "documentType": "CC",
+    "document": "1020304050"
+  },
+  "billing": {
+    "contact": "Contabilidad Acme",
+    "mail": "facturacion@acme.example.com",
+    "registrationNumber": "9001234567-1",
+    "ciiu": "4791",
+    "taxType": 1,
+    "taxRegime": 1,
+    "organizationType": 1
+  },
+  "travelAgency": {
+    "dispersion": false,
+    "iata": "ABCD12"
+  },
+  "control": {
+    "reseller": 1,
+    "seller": 1,
+    "paymentFacilitator": null
+  },
+  "integrations": [
     {
-      "name": "Comercializadora Acme S.A.S.",
-      "brand": "Acme",
+      "type": "kount",
+      "settings": {
+        "sandbox": false,
+        "website": "ACME",
+        "merchant": "201000"
+      }
+    },
+    {
+      "type": "push_notification",
+      "settings": {
+        "enabled": true
+      }
+    }
+  ],
+  "paymentMethods": [
+    {
+      "code": "CR_VS",
+      "financialEntity": 7,
+      "accountNumber": "1234567890",
+      "accountType": 2,
+      "commissionModel": "P",
+      "commissionValue": 2.5,
+      "order": 1,
+      "creditRules": {
+        "minInstallments": 1,
+        "maxInstallments": 36
+      },
+      "settings": {
+        "merchantCode": "201000",
+        "terminalNumber": "00000001",
+        "isEcommerce": true,
+        "threeDSProvider": "placetopay"
+      }
+    }
+  ],
+  "sites": [
+    {
+      "login": "aabbccdd1234567890aabbccdd123456",
+      "name": "Tienda principal",
+      "displayName": "Acme",
+      "type": "INT",
+      "category": "ECOMMERCE",
       "active": true,
-      "url": "https://acme.example.com",
-      "mcc": "5411",
-      "size": "M",
-      "timezone": "America/Bogota",
-      "languages": ["es", "en"],
-      "currencies": ["COP", "USD"],
-      "document": {
-        "type": "NIT",
-        "number": "9001234567"
-      },
-      "address": {
-        "street": "Carrera 43A # 1-50, Torre 2",
-        "city": "Bogota",
-        "country": "CO",
-        "state": 11,
-        "phone": "6013905000",
-        "postalCode": "110111"
-      },
-      "legalRepresentative": {
-        "name": "Ada",
-        "surname": "Lovelace",
-        "documentType": "CC",
-        "document": "1020304050"
-      },
-      "billing": {
-        "contact": "Contabilidad Acme",
-        "mail": "facturacion@acme.example.com",
-        "ciiu": "4791",
-        "taxType": 1,
-        "taxRegime": 1,
-        "organizationType": 1
+      "onTest": false,
+      "currency": "COP",
+      "language": "es",
+      "email": "ops@acme.example.com",
+      "customBatch": 1,
+      "expiration": "2027-01-31 23:59:59",
+      "productionDate": "2026-09-01",
+      "integration": {
+        "allowPartial": false,
+        "checkoutVersion": "v4",
+        "connectionMethod": "REDIRECT",
+        "notificationUrl": "https://acme.example.com/pay/notify",
+        "analyticsCode": "G-ABCDE12345",
+        "sourceRestriction": null,
+        "allowWallet": true,
+        "checkoutAttemptsLimit": 5,
+        "returnAdditional": false,
+        "payerFieldsType": 0
       },
       "control": {
-        "reseller": 1,
-        "seller": 1
+        "minAmount": 1000,
+        "maxAmount": 5000000,
+        "allowedDays": 127,
+        "allowedHours": "ffffffffffffffffffffffffffffffffffffffffff",
+        "filterPse": false,
+        "filterByBin": false,
+        "filterTuya": false,
+        "filterSafetypay": false,
+        "prechargeFilter": 0,
+        "allowedBankCountries": ["CO"],
+        "exceptionBinsList": ["411111"],
+        "delegatedAuthorization": null
+      },
+      "threeDS": {
+        "setting": "LOW",
+        "minAmount": 100000
+      },
+      "securityFilters": {
+        "filterLockedByTries": true,
+        "forceIPMatch": false,
+        "onlyWhitelisted": false,
+        "allowedIssuerCountries": ["CO"],
+        "allowedIPCountries": ["CO", "US"],
+        "excludeIPCountry": null,
+        "allowedCardsDay": 5,
+        "allowedCardsMonth": 20,
+        "allowedCardsYear": 60,
+        "allowedCardsByIP": 10,
+        "dayMax": 5,
+        "monthMax": 100,
+        "dayMaxAmount": 10000000,
+        "monthMaxAmount": 200000000
+      },
+      "operation": {
+        "disableTax": false,
+        "calculateTax": true,
+        "mailCustomer": true,
+        "mailMerchant": false,
+        "taxPercentage": 19,
+        "patternReference": "1234567890"
+      },
+      "subscriptionValidation": {
+        "enable": true,
+        "amount": 1000
+      },
+      "branding": {
+        "buttonColor": "#1a73e8",
+        "sidebarColor": "#0b1220"
+      },
+      "metadata": {
+        "contractRef": "AC-2026-0042",
+        "onboardingBatch": 17
       },
       "integrations": [
         {
-          "type": "kount",
+          "type": "clicktopay_visa",
           "settings": {
-            "sandbox": false,
-            "website": "ACME",
-            "merchant": "201000"
+            "enabled": true
           }
         }
       ],
@@ -155,19 +279,57 @@ Un registro real suele incluir también las colecciones. Este ejemplo muestra la
           "financialEntity": 7,
           "accountNumber": "1234567890",
           "accountType": 2,
+          "minAmount": 2000,
+          "maxAmount": 900000,
           "commissionModel": "P",
-          "commissionValue": 2.5
+          "commissionValue": 2.5,
+          "order": 1,
+          "settings": {
+            "terminalNumber": "00000002"
+          }
         }
-      ],
-      "notification": {
-        "url": "https://acme.example.com/hooks/onboarding"
-      }
+      ]
     }
-    ```
+  ],
+  "notification": {
+    "url": "https://acme.example.com/hooks/onboarding"
+  }
+}
+```
 
-    </CodeGroup>
-  </Col>
-</Row>
+</CodeGroup>
+
+<Note>
+  Los valores de catálogo —`mcc`, `size`, `timezone`, `state`, `taxType`, `taxRegime`, `organizationType`, `reseller`, `seller`, `paymentFacilitator`, `code`, `financialEntity`, `accountType`— salen de los catálogos de Placetopay y **dependen del ambiente**. Los del ejemplo son ilustrativos: pide los tuyos junto con las credenciales, porque un identificador válido en un ambiente no tiene por qué serlo en otro. Además, `reseller` y `seller` deben estar habilitados, no solo existir.
+</Note>
+
+### Un sitio obliga a mucho más que un comercio {{ id: 'site-required-fields' }}
+
+`sites` es opcional, pero **en cuanto envías un sitio casi todo lo suyo pasa a ser obligatorio**: `name`, `displayName`, `type`, `category`, `currency`, `language`, `email` y los bloques `integration` y `control` completos —con sus propios `allowPartial`, `checkoutVersion`, `minAmount`, `maxAmount`, `allowedDays`, `allowedHours`, `filterPse` y `filterByBin`—. El resto de bloques (`threeDS`, `securityFilters`, `operation`, `subscriptionValidation`, `branding`, `metadata`) sigue siendo opcional. El detalle está en [Sitios](/onboarding/sites).
+
+Tres formatos que suelen sorprender:
+
+- **El sitio distingue mayúsculas donde la raíz no.** `languages` y `currencies` de la raíz aceptan cualquier grafía, pero `sites[].language` y `sites[].currency` exigen la del catálogo, que hoy escribe el idioma en minúscula (`es`) y la moneda en mayúscula (`COP`). Un `"language": "ES"` dentro de un sitio responde `422` — y el mensaje del error te dice la grafía que espera.
+- **`allowedHours` son 42 caracteres hexadecimales exactos.** Una cadena más corta no produce un error: produce un horario equivocado.
+- **`sites[].paymentMethods[].code` solo puede nombrar un medio de pago que este mismo cuerpo declaró** en el `paymentMethods` de la raíz. Al crear no hay nada preexistente a lo que apuntar, porque el comercio todavía no existe.
+- **Dentro del sitio basta el `code`.** Los datos de cuenta y comisión son obligatorios en el `paymentMethods` de la raíz, pero opcionales dentro de un sitio: lo que no nombras se hereda del medio de pago del comercio. Envía solo lo que deba diferir.
+
+### Lo que el ejemplo deja fuera {{ id: 'omitted-credentials' }}
+
+Un sitio admite además tres credenciales —`login`, `tranKey` y `md5Hash`, de hasta 32 caracteres cada una— que aquí se omiten a propósito. Si no las envías, Onboarding las genera y te las devuelve en el resultado del proceso, que es la forma recomendada de obtenerlas; las que genera son de 16 caracteres. El ejemplo solo conserva `login` para mostrar dónde va.
+
+## Campos que la petición rechaza {{ id: 'rejected-fields' }}
+
+Estos campos no son ignorados: si viajan en el cuerpo de una creación, la respuesta es `422` nombrándolos. Casi todos son identificadores que solo tienen sentido cuando el comercio ya existe, así que aparecen al reenviar como petición un cuerpo copiado de una respuesta.
+
+| Campo | Por qué |
+|---|---|
+| `id`, `merchantId` en la raíz | El identificador del comercio viaja en la URL, no en el cuerpo — y en una creación todavía no existe |
+| `integrations[].id` | Una integración se identifica por su `type` |
+| `paymentMethods[].id` | Solo existe al [actualizar](/onboarding/update-merchant); al crear, la identidad es el `code` |
+| `sites[].id`, `sites[].customerId` | El sitio se está creando |
+| `sites[].integrations[].siteId` | El sitio que la lleva es el que la contiene |
+| `sites[].paymentMethods[].id`, `.paymentMethodId`, `.siteId` | Al crear, la única forma de nombrar un medio de pago es su `code` |
 
 ## La URL de notificación {{ id: 'notification-url' }}
 

--- a/src/pages/onboarding/site-payment-methods.mdx
+++ b/src/pages/onboarding/site-payment-methods.mdx
@@ -25,6 +25,8 @@ Cada elemento indica de qué fila habla de **una sola de estas tres maneras**. E
   `siteId` responde `422` siempre: el sitio es el elemento que contiene la colección, no un campo suyo.
 </Note>
 
+En una frase: **`paymentMethodId` habilita, `id` modifica lo ya habilitado.** De ahí sale el caso que más confunde — un sitio que **se está creando** dentro de una actualización sí puede usar `paymentMethodId`, porque ese identificador señala una fila del **comercio**, que existe. Lo que no puede es usar `id`, porque no tiene todavía ninguna habilitación propia que modificar. El error lo dice tal cual: `A site being created carries no payment method to address.`
+
 Los dos identificadores los publica el resultado de un proceso: `paymentMethodId` sale de `result.paymentMethods[].id` y el `id` de la habilitación, de `result.sites[].paymentMethods[].id`. Consérvalos, porque [no hay forma de consultarlos después](/onboarding/payment-methods#where-the-id-comes-from).
 
 ### `id` — modificar una habilitación existente
@@ -173,7 +175,8 @@ La marca se escribe solo cuando algo cambió realmente, y nunca en un sitio que 
 | Un `paymentMethodId` que no pertenece al comercio | `422` sobre `paymentMethodId` |
 | Un `paymentMethodId` que el sitio ya tiene habilitado | `422` sobre `paymentMethodId` |
 | Un `code` que la raíz del cuerpo no declara, o declara dos veces | `422` sobre `code` |
-| `id` o `paymentMethodId` en una creación, o en un sitio que se está creando | `422` |
+| `id` o `paymentMethodId` en una creación (`POST`) | `422` |
+| `id` en un sitio que se está creando dentro de un `PATCH` | `422` |
 | Dos elementos del mismo sitio que señalan el mismo medio de pago | `422` |
 
 <Note>

--- a/src/pages/onboarding/sites.mdx
+++ b/src/pages/onboarding/sites.mdx
@@ -17,7 +17,7 @@ Lo que determina si un elemento crea un sitio nuevo o modifica uno existente es 
 | **Con `id`** | Modifica ese sitio. Solo cambia lo que nombras; el resto se conserva |
 
 <Note>
-  `sites[].id` es la **única excepción** a la regla de que los identificadores no viajan en el cuerpo. Es necesaria porque un sitio no tiene otro campo estable con el que referenciarlo: su nombre de acceso puede cambiarlo la misma petición.
+  La regla es más precisa de lo que parece: el identificador del **comercio** nunca viaja en el cuerpo —va siempre en la URL, y `id`, `merchantId` o `customerId` responden `422`—, pero los de sus **recursos hijos** sí, y son justamente la forma de direccionar filas existentes: `sites[].id`, `paymentMethods[].id`, y en `sites[].paymentMethods[]` tanto `id` como `paymentMethodId`.
 </Note>
 
 En una creación (`POST`), enviar `sites[].id` responde `422`, porque no hay sitios previos que modificar. En una actualización, el `id` debe pertenecer al comercio de la URL. El campo `customerId` responde `422` siempre: el comercio viaja en la URL.
@@ -90,7 +90,7 @@ Como el `login` no distingue mayúsculas, `ACME` y `acme` son el mismo identific
           "category": "ECOMMERCE",
           "email": "ops@acme.example.com",
           "currency": "COP",
-          "language": "ES",
+          "language": "es",
           "onTest": true,
           "integration": {
             "allowPartial": false,
@@ -390,14 +390,16 @@ No hay forma de volver a leerlas: ningún endpoint las devuelve. Lo que sí pued
           {
             "id": 214,
             "login": "aabbccdd1234567890aabbccdd123456",
-            "tranKey": "ABC123example456trankey+789abc012def3456ABC=",
+            "tranKey": "exampleTranKey16",
+            "md5Hash": "exampleMd5Hash16",
             "active": true,
             "action": "created"
           },
           {
             "id": 209,
-            "login": "123example456token789abc012def345",
+            "login": "example456token789abc012def3456",
             "tranKey": null,
+            "md5Hash": null,
             "active": true,
             "action": "updated"
           }


### PR DESCRIPTION
## Descripción general

La documentación de la API de Onboarding mostraba, en todos sus ejemplos, únicamente el cuerpo mínimo necesario para registrar un comercio. Quien integraba no tenía forma de saber qué más acepta la petición sin leer el contrato campo a campo, y una colección entera —`sites`— no aparecía en ningún ejemplo.

Este PR amplía los ejemplos hasta cubrir el request completo, añade escenarios seleccionables en los tres endpoints de la referencia y corrige varios datos que no correspondían al comportamiento real de la API.

## Qué cambia

### Referencia de API

Los bloques de solicitud pasan de un único ejemplo a un selector de escenarios, siguiendo el patrón que ya usa la documentación de Web Checkout:

| Endpoint | Escenarios |
|---|---|
| **Crear un comercio** | Datos mínimos · Con sitios y medios de pago · Con todos los campos |
| **Actualizar un comercio** | Cambiar datos del comercio · Modificar un medio de pago existente · Añadir un sitio |
| **Consultar un proceso** | Consulta simple · Ver los headers · Sondear hasta que termine |

El escenario de sondeo es nuevo: muestra cómo usar la presencia del header `Retry-After` como única condición de parada, que es la duda habitual al integrar una API asíncrona.

### Guía de Onboarding

- **Crear un comercio** incluye ahora el cuerpo completo con todos los campos que la petición acepta, incluida la colección `sites` con sus bloques anidados, que antes no aparecía en ningún ejemplo.
- Se documentan los **topes de cada colección** y los **campos que la petición rechaza** con `422` en lugar de ignorarlos, que es el error típico al reenviar como petición un cuerpo copiado de una respuesta.
- Se explica que un sitio, aunque sea opcional, convierte en obligatorios sus propios campos y dos bloques completos.

## Correcciones

- **Grafía de los catálogos.** Dentro de un sitio, `language` y `currency` distinguen mayúsculas, a diferencia de sus equivalentes en la raíz del cuerpo. El valor que publicábamos para el idioma del sitio devolvía `422`.
- **Direccionamiento de medios de pago en un sitio.** La documentación agrupaba `id` y `paymentMethodId` como si se comportaran igual. No es así: `paymentMethodId` habilita un medio de pago del comercio y funciona incluso en un sitio que se está creando; `id` modifica una habilitación que ya existe y por eso es imposible en un sitio nuevo.
- **Identificadores en el cuerpo.** Se afirmaba que `sites[].id` era la única excepción a que los identificadores no viajen en el cuerpo. La regla real es que el identificador del *comercio* nunca viaja en el cuerpo, mientras que los de sus recursos hijos sí, y son el mecanismo para direccionar filas existentes.
- **Credenciales de ejemplo.** Los valores publicados para `tranKey` y `login` tenían longitudes que la API no puede generar. Se ajustan y se documenta la longitud real de las credenciales generadas.
- **`patternReference`** admite solo dígitos; el contrato lo declaraba como texto libre.
- Se añaden al contrato los topes de las colecciones `sites` y `paymentMethods`, que no estaban declarados.

## Verificación

Los valores y comportamientos nuevos se comprobaron ejecutando las peticiones contra la API, no deduciéndolos de su implementación. Varios de los cambios previstos inicialmente se descartaron al comprobar que la documentación publicada ya era correcta.

`npm run build` y `npm run scan:sensitive` en verde. Todos los cambios están replicados en las versiones en español e inglés.