### PR TITLE
update checkout .ymal

### DIFF
--- a/src/assets/apis/checkout/en.yaml
+++ b/src/assets/apis/checkout/en.yaml
@@ -2641,6 +2641,37 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/NameValuePair'
+    RedirectRequestInformation:
+      title: RedirectRequestInformation
+      type: object
+      description: |
+        Session information returned when querying it. It contains only the data the API returns,
+        not every property that can be sent when creating the session.
+      properties:
+        payment:
+          $ref: '#/components/schemas/RedirectRequest/properties/payment'
+        expiration:
+          $ref: '#/components/schemas/RedirectRequest/properties/expiration'
+        ipAddress:
+          $ref: '#/components/schemas/RedirectRequest/properties/ipAddress'
+        userAgent:
+          $ref: '#/components/schemas/RedirectRequest/properties/userAgent'
+        returnUrl:
+          $ref: '#/components/schemas/RedirectRequest/properties/returnUrl'
+        locale:
+          $ref: '#/components/schemas/RedirectRequest/properties/locale'
+        buyer:
+          $ref: '#/components/schemas/RedirectRequest/properties/buyer'
+        payer:
+          $ref: '#/components/schemas/RedirectRequest/properties/payer'
+        subscription:
+          $ref: '#/components/schemas/RedirectRequest/properties/subscription'
+        fields:
+          $ref: '#/components/schemas/RedirectRequest/properties/fields'
+        metadata:
+          $ref: '#/components/schemas/RedirectRequest/properties/metadata'
+        autopay:
+          $ref: '#/components/schemas/RedirectRequest/properties/autopay'
     RedirectInformation:
       title: RedirectInformation
       type: object
@@ -2656,7 +2687,7 @@ components:
         status:
           $ref: '#/components/schemas/Status'
         request:
-          $ref: '#/components/schemas/RedirectRequest'
+          $ref: '#/components/schemas/RedirectRequestInformation'
         payment:
           type: array
           items:

--- a/src/assets/apis/checkout/es.yaml
+++ b/src/assets/apis/checkout/es.yaml
@@ -2643,6 +2643,37 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/NameValuePair'
+    RedirectRequestInformation:
+      title: RedirectRequestInformation
+      type: object
+      description: |
+        Información de la sesión retornada al consultarla. Contiene únicamente los datos que devuelve la API,
+        no todas las propiedades que se pueden enviar al crear la sesión.
+      properties:
+        payment:
+          $ref: '#/components/schemas/RedirectRequest/properties/payment'
+        expiration:
+          $ref: '#/components/schemas/RedirectRequest/properties/expiration'
+        ipAddress:
+          $ref: '#/components/schemas/RedirectRequest/properties/ipAddress'
+        userAgent:
+          $ref: '#/components/schemas/RedirectRequest/properties/userAgent'
+        returnUrl:
+          $ref: '#/components/schemas/RedirectRequest/properties/returnUrl'
+        locale:
+          $ref: '#/components/schemas/RedirectRequest/properties/locale'
+        buyer:
+          $ref: '#/components/schemas/RedirectRequest/properties/buyer'
+        payer:
+          $ref: '#/components/schemas/RedirectRequest/properties/payer'
+        subscription:
+          $ref: '#/components/schemas/RedirectRequest/properties/subscription'
+        fields:
+          $ref: '#/components/schemas/RedirectRequest/properties/fields'
+        metadata:
+          $ref: '#/components/schemas/RedirectRequest/properties/metadata'
+        autopay:
+          $ref: '#/components/schemas/RedirectRequest/properties/autopay'
     RedirectInformation:
       title: RedirectInformation
       type: object
@@ -2658,7 +2689,7 @@ components:
         status:
           $ref: '#/components/schemas/Status'
         request:
-          $ref: '#/components/schemas/RedirectRequest'
+          $ref: '#/components/schemas/RedirectRequestInformation'
         payment:
           type: array
           items:
@@ -2781,15 +2812,10 @@ components:
               - keyword: _processUrl_
                 value: 'https://checkout.redirection.test/session/1/a592098e22acc709ec7eb30fc0973060'
                 displayOn: none
-            paymentMethod: visa
             expiration: '2019-08-24T14:15:22Z'
             returnUrl: 'https://commerce.test/return'
-            cancelUrl: 'https://commerce.test/cancel'
             ipAddress: 127.0.0.1
             userAgent: Placetopay Sandbox
-            skipResult: false
-            noBuyerFill: false
-            type: checkin
           payment:
             - status:
                 status: APPROVED

--- a/src/pages/checkout/api/reference/session.mdx
+++ b/src/pages/checkout/api/reference/session.mdx
@@ -758,15 +758,10 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
         "displayOn": "none"
       }
     ],
-    "paymentMethod": "visa",
     "expiration": "2019-08-24T14:15:22Z",
     "returnUrl": "https://commerce.test/return",
-    "cancelUrl": "https://commerce.test/cancel",
     "ipAddress": "127.0.0.1",
-    "userAgent": "Placetopay Sandbox",
-    "skipResult": false,
-    "noBuyerFill": false,
-    "type": "checkin"
+    "userAgent": "Placetopay Sandbox"
   },
   "payment": [
     {
@@ -1449,7 +1444,6 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
       "email": "root13@app.com",
       "mobile": "+573111111111"
     },
-    "type": "autopay",
     "autopay": {
       "action": "CREATE",
       "reference": "12345",

--- a/src/pages/en/checkout/api/reference/session.mdx
+++ b/src/pages/en/checkout/api/reference/session.mdx
@@ -759,15 +759,10 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
         "displayOn": "none"
       }
     ],
-    "paymentMethod": "visa",
     "expiration": "2019-08-24T14:15:22Z",
     "returnUrl": "https://commerce.test/return",
-    "cancelUrl": "https://commerce.test/cancel",
     "ipAddress": "127.0.0.1",
-    "userAgent": "Placetopay Sandbox",
-    "skipResult": false,
-    "noBuyerFill": false,
-    "type": "checkin"
+    "userAgent": "Placetopay Sandbox"
   },
   "payment": [
     {
@@ -1450,7 +1445,6 @@ curl -X "POST" https://checkout-test.placetopay.com/api/session/000000 \
       "email": "root13@app.com",
       "mobile": "+573111111111"
     },
-    "type": "autopay",
     "autopay": {
       "action": "CREATE",
       "reference": "12345",


### PR DESCRIPTION
La respuesta de `getSessionInformation` documentaba propiedades dentro de `request`
que la API no devuelve, porque reutilizaba el schema de creación de sesión.

Ahora tiene el suyo, `RedirectRequestInformation`, sin `paymentMethod`, `cancelUrl`,
`skipResult`, `noBuyerFill`, `type` ni `auth`.

Solo documentación, en español e inglés. `POST /api/session` no se toca. El cancel
hereda el arreglo porque comparte la misma respuesta.